### PR TITLE
Feature/attributes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+# Unreleased
+
+- Attributes are now generated as dartdoc unless there exists a known mapping to an existing dart annotation. For now `@[Dd]eprecated` is the only known mapping
+
 # 0.2.1
 
 - Rename identifiers that would cause syntax errors

--- a/README.md
+++ b/README.md
@@ -67,7 +67,3 @@ Future<void> main(List<String> arguments) async {
   await generator.writeAll();
 }
 ```
-
-## Todo
-
-- Attributes. Currently completely ignored

--- a/example/ExampleContracts/Users/UserInfoDTO.cs
+++ b/example/ExampleContracts/Users/UserInfoDTO.cs
@@ -1,8 +1,11 @@
 namespace LeanCode.ContractsGeneratorV2.ExampleContracts.Users
 {
+    [System.Obsolete("Use something else instead")]
     public class UserInfoDTO
     {
         public string Firstname { get; set; }
+        
+        [System.Obsolete]
         public string Surname { get; set; }
         public string Username { get; set; }
         public string EmailAddress { get; set; }

--- a/example/lib/cool_name.dart
+++ b/example/lib/cool_name.dart
@@ -135,6 +135,8 @@ class ISomethingRelated with EquatableMixin {
   Map<String, dynamic> toJson() => _$ISomethingRelatedToJson(this);
 }
 
+/// System.Diagnostics.CodeAnalysis.SuppressMessageAttribute('?', 'SA1302', Justification: 'Convention for authorizers.')
+/// System.Diagnostics.CodeAnalysis.SuppressMessageAttribute('?', 'IDE1006', Justification: 'Convention for authorizers.')
 @JsonSerializable(fieldRename: FieldRename.pascal)
 class WhenHasSomethingAccess with EquatableMixin {
   WhenHasSomethingAccess();
@@ -147,6 +149,7 @@ class WhenHasSomethingAccess with EquatableMixin {
   Map<String, dynamic> toJson() => _$WhenHasSomethingAccessToJson(this);
 }
 
+/// LeanCode.CQRS.Security.AuthorizeWhenHasAnyOfAttribute('admin')
 @JsonSerializable(fieldRename: FieldRename.pascal)
 class AllUsers with EquatableMixin implements PaginatedQuery<UserInfoDTO> {
   AllUsers({
@@ -171,6 +174,8 @@ class AllUsers with EquatableMixin implements PaginatedQuery<UserInfoDTO> {
       'LeanCode.ContractsGeneratorV2.ExampleContracts.Users.AllUsers';
 }
 
+/// LeanCode.CQRS.Security.AuthorizeWhenHasAnyOfAttribute('admin')
+/// LeanCode.ContractsGeneratorV2.ExampleContracts.Security.AuthorizeWhenHasSomethingAccessAttribute()
 @JsonSerializable(fieldRename: FieldRename.pascal)
 class EditUser
     with EquatableMixin
@@ -230,6 +235,7 @@ class EditUserErrorCodes {
   static const userInfoEmailIsTaken = 1010;
 }
 
+/// LeanCode.CQRS.Security.AuthorizeWhenHasAnyOfAttribute('admin')
 @JsonSerializable(fieldRename: FieldRename.pascal)
 class UserById with EquatableMixin implements IRemoteQuery<UserInfoDTO?> {
   UserById();
@@ -247,6 +253,7 @@ class UserById with EquatableMixin implements IRemoteQuery<UserInfoDTO?> {
       'LeanCode.ContractsGeneratorV2.ExampleContracts.Users.UserById';
 }
 
+@Deprecated('Use something else instead')
 @JsonSerializable(fieldRename: FieldRename.pascal)
 class UserInfoDTO with EquatableMixin {
   UserInfoDTO({
@@ -261,6 +268,7 @@ class UserInfoDTO with EquatableMixin {
 
   final String firstname;
 
+  @deprecated
   final String surname;
 
   final String username;
@@ -272,6 +280,7 @@ class UserInfoDTO with EquatableMixin {
   Map<String, dynamic> toJson() => _$UserInfoDTOToJson(this);
 }
 
+/// LeanCode.CQRS.Security.AuthorizeWhenHasAnyOfAttribute('admin')
 @JsonSerializable(fieldRename: FieldRename.pascal)
 class UserSomething with EquatableMixin implements IRemoteQuery<int?> {
   UserSomething();

--- a/example/lib/data/contracts.dart
+++ b/example/lib/data/contracts.dart
@@ -32,6 +32,7 @@ class Time with EquatableMixin {
   String toJson() => '$hour:$minute:$second';
 }
 
+/// LeanCode.CQRS.Security.AllowUnauthorizedAttribute()
 @JsonSerializable(fieldRename: FieldRename.pascal)
 class Command with EquatableMixin implements IRemoteCommand {
   Command();
@@ -47,6 +48,7 @@ class Command with EquatableMixin implements IRemoteCommand {
 
 class CommandErrorCodes {}
 
+/// LeanCode.CQRS.Security.AllowUnauthorizedAttribute()
 @JsonSerializable(fieldRename: FieldRename.pascal)
 class Query with EquatableMixin implements IRemoteQuery<int> {
   Query();

--- a/example/pubspec.lock
+++ b/example/pubspec.lock
@@ -126,7 +126,7 @@ packages:
       path: ".."
       relative: true
     source: path
-    version: "0.1.0"
+    version: "0.2.1"
   convert:
     dependency: transitive
     description:

--- a/lib/src/attributes/attribute_creator.dart
+++ b/lib/src/attributes/attribute_creator.dart
@@ -4,7 +4,7 @@ import '../proto/contracts.pb.dart';
 import '../values/value_creator.dart';
 
 /// Translates attributes to a dartdoc comment,
-/// or to a `package:meta` annotation if an appropriate mapping exists
+/// or to a dart annotation if an appropriate mapping exists
 class AttributeCreator {
   const AttributeCreator(this.valueCreator);
 

--- a/lib/src/attributes/attribute_creator.dart
+++ b/lib/src/attributes/attribute_creator.dart
@@ -1,0 +1,44 @@
+import 'package:collection/collection.dart';
+
+import '../proto/contracts.pb.dart';
+import '../values/value_creator.dart';
+
+/// Translates attributes to a dartdoc comment,
+/// or to a `package:meta` annotation if an appropriate mapping exists
+class AttributeCreator {
+  const AttributeCreator(this.valueCreator);
+
+  final ValueCreator valueCreator;
+
+  String create(AttributeRef attributeRef) {
+    final knownMapping = maybeHandleDeprecated(attributeRef);
+    if (knownMapping != null) return knownMapping;
+
+    final params = [
+      for (final param in attributeRef.argument)
+        if (param.hasPositional())
+          valueCreator.create(param.positional.value).assignment.toString()
+        else if (param.hasNamed())
+          '${param.named.name}: ${valueCreator.create(param.named.value).assignment}'
+        else
+          throw StateError('Unhandled AttributeRef variant')
+    ];
+
+    return '/// ${attributeRef.attributeName}(${params.join(', ')})';
+  }
+
+  String? maybeHandleDeprecated(AttributeRef attributeRef) {
+    if (attributeRef.attributeName != 'System.ObsoleteAttribute') return null;
+
+    // this attribute can have zero, one, or two positional arguments
+    // we don't care about the 'two' case
+    final valueRef =
+        attributeRef.argument.firstOrNull?.ensurePositional().value;
+
+    if (valueRef == null) {
+      return '@deprecated';
+    } else {
+      return '@Deprecated(${valueCreator.create(valueRef).assignment})';
+    }
+  }
+}

--- a/lib/src/contracts_generator.dart
+++ b/lib/src/contracts_generator.dart
@@ -10,6 +10,7 @@ import 'package:dart_style/dart_style.dart';
 import 'package:json_serializable/builder.dart';
 import 'package:path/path.dart' as p;
 
+import 'attributes/attribute_creator.dart';
 import 'contracts_generator_config.dart';
 import 'errors/error_creator.dart';
 import 'generator_database.dart';
@@ -57,11 +58,18 @@ class ContractsGenerator {
     ]);
     const valueCreator = ValueCreator();
     const errorCreator = ErrorCreator();
+    const attributeCreator = AttributeCreator(valueCreator);
     final statementCreator = StatementCreator([
-      DtoHandler(typeCreator, valueCreator, db),
-      QueryHandler(typeCreator, valueCreator, db),
-      CommandHandler(typeCreator, valueCreator, db, errorCreator),
-      EnumHandler(typeCreator, valueCreator, db),
+      DtoHandler(typeCreator, valueCreator, attributeCreator, db),
+      QueryHandler(typeCreator, valueCreator, attributeCreator, db),
+      CommandHandler(
+        typeCreator,
+        valueCreator,
+        attributeCreator,
+        db,
+        errorCreator,
+      ),
+      EnumHandler(typeCreator, valueCreator, attributeCreator, db),
     ]);
 
     final body = [

--- a/lib/src/contracts_generator.dart
+++ b/lib/src/contracts_generator.dart
@@ -24,8 +24,6 @@ import 'types/generic_type_handler.dart';
 import 'types/internal_type_handler.dart';
 import 'types/known_type_handler.dart';
 import 'types/type_creator.dart';
-import 'types/type_handler.dart';
-import 'types/utils/known_type_kind.dart';
 import 'values/value_creator.dart';
 
 class ContractsGenerator {
@@ -34,18 +32,6 @@ class ContractsGenerator {
   final ContractsGeneratorConfig config;
 
   static final emitter = DartEmitter();
-
-  // TODO: for now attributes won't be generated
-  bool _isAttribute(Statement statement) {
-    // a statement is an attribute if it extends an attribute
-    // TODO: this should be a deep check, the extend might be higher in the tree
-    return statement.hasDto() &&
-        statement.dto.typeDescriptor.extends_1.isNotEmpty &&
-        statement.dto.typeDescriptor.extends_1.first.hasKnown() &&
-        knownTypeKind(
-                statement.dto.typeDescriptor.extends_1.first.known.type) ==
-            KnownTypeKind.attribute;
-  }
 
   /// generates `code_builder` structures that can still be modified
   Future<Library> generate() async {
@@ -74,7 +60,7 @@ class ContractsGenerator {
 
     final body = [
       for (final statement in db.statements)
-        if (db.shouldInclude(statement.name) && !_isAttribute(statement))
+        if (db.shouldInclude(statement.name) && !db.isAttribute(statement))
           statementCreator.create(statement)
     ];
 

--- a/lib/src/errors/error_creator.dart
+++ b/lib/src/errors/error_creator.dart
@@ -3,7 +3,6 @@ import 'package:code_builder/code_builder.dart';
 import '../proto/contracts.pb.dart';
 import '../utils/rename_field.dart';
 
-// TODO: split into handlers?
 class ErrorCreator {
   const ErrorCreator();
 

--- a/lib/src/generator_database.dart
+++ b/lib/src/generator_database.dart
@@ -123,7 +123,7 @@ class GeneratorDatabase {
       _isKindCache[kind]!.add(name);
     }
 
-    return _isKindCache[kind]!.add(name);
+    return _isKindCache[kind]!.contains(name);
   }
 
   /// Deep check for whether this type is/extends a CQRS type

--- a/lib/src/generator_database.dart
+++ b/lib/src/generator_database.dart
@@ -97,26 +97,45 @@ class GeneratorDatabase {
     return _resolveCache[namespacedName]!;
   }
 
-  final _isCqrsCache = HashSet<String>();
+  final _isKindCache = {
+    KnownTypeKind.cqrs: HashSet<String>(),
+    KnownTypeKind.attribute: HashSet<String>(),
+  };
 
-  /// Deep check for whether this type is/extends a CQRS type
-  bool isCqrs(TypeRef typeRef) {
+  /// Deep check for whether this type is/extends a CQRS/Attribute type
+  bool _isKind(TypeRef typeRef, KnownTypeKind kind) {
+    assert(kind == KnownTypeKind.cqrs || kind == KnownTypeKind.attribute);
+
     if (typeRef.hasKnown()) {
-      return knownTypeKind(typeRef.known.type) == KnownTypeKind.cqrs;
+      return knownTypeKind(typeRef.known.type) == kind;
     } else if (typeRef.hasGeneric()) {
       return false;
     }
 
     final name = typeRef.ensureInternal().name;
 
-    if (_isCqrsCache.contains(name)) return true;
+    if (_isKindCache[kind]!.contains(name)) return true;
 
     final statement = find(name)!;
 
-    if (typeDescriptorOf(statement)?.extends_1.any(isCqrs) ?? false) {
-      _isCqrsCache.add(name);
+    if (typeDescriptorOf(statement)?.extends_1.any((e) => _isKind(e, kind)) ??
+        false) {
+      _isKindCache[kind]!.add(name);
     }
 
-    return _isCqrsCache.contains(name);
+    return _isKindCache[kind]!.add(name);
+  }
+
+  /// Deep check for whether this type is/extends a CQRS type
+  bool isCqrs(TypeRef typeRef) {
+    return _isKind(typeRef, KnownTypeKind.cqrs);
+  }
+
+  /// Deep check for whether this statement is/extends an Attribute type
+  bool isAttribute(Statement statement) {
+    return statement.hasDto() &&
+        statement.dto.typeDescriptor.extends_1.any(
+          (e) => _isKind(e, KnownTypeKind.attribute),
+        );
   }
 }

--- a/lib/src/statements/command_handler.dart
+++ b/lib/src/statements/command_handler.dart
@@ -1,5 +1,6 @@
 import 'package:code_builder/code_builder.dart';
 
+import '../attributes/attribute_creator.dart';
 import '../errors/error_creator.dart';
 import '../generator_database.dart';
 import '../types/type_creator.dart';
@@ -11,9 +12,10 @@ class CommandHandler extends StatementHandler {
   const CommandHandler(
     TypeCreator typeCreator,
     ValueCreator valueCreator,
+    AttributeCreator attributeCreator,
     GeneratorDatabase db,
     this.errorCreator,
-  ) : super(typeCreator, valueCreator, db);
+  ) : super(typeCreator, valueCreator, attributeCreator, db);
 
   final ErrorCreator errorCreator;
 

--- a/lib/src/statements/dto_handler.dart
+++ b/lib/src/statements/dto_handler.dart
@@ -1,5 +1,6 @@
 import 'package:code_builder/code_builder.dart';
 
+import '../attributes/attribute_creator.dart';
 import '../generator_database.dart';
 import '../types/type_creator.dart';
 import '../values/value_creator.dart';
@@ -9,8 +10,9 @@ class DtoHandler extends StatementHandler {
   const DtoHandler(
     TypeCreator typeCreator,
     ValueCreator valueCreator,
+    AttributeCreator attributeCreator,
     GeneratorDatabase db,
-  ) : super(typeCreator, valueCreator, db);
+  ) : super(typeCreator, valueCreator, attributeCreator, db);
 
   @override
   Spec build(Statement statement) {

--- a/lib/src/statements/enum_handler.dart
+++ b/lib/src/statements/enum_handler.dart
@@ -1,5 +1,6 @@
 import 'package:code_builder/code_builder.dart';
 
+import '../attributes/attribute_creator.dart';
 import '../generator_database.dart';
 import '../types/type_creator.dart';
 import '../utils/rename_field.dart';
@@ -11,8 +12,9 @@ class EnumHandler extends StatementHandler {
   const EnumHandler(
     TypeCreator typeCreator,
     ValueCreator valueCreator,
+    AttributeCreator attributeCreator,
     GeneratorDatabase db,
-  ) : super(typeCreator, valueCreator, db);
+  ) : super(typeCreator, valueCreator, attributeCreator, db);
 
   @override
   Spec build(Statement statement) {
@@ -22,7 +24,10 @@ class EnumHandler extends StatementHandler {
     return Enum(
       (b) => b
         ..name = name
-        ..docs.addAll(toDartdoc(statement.comment))
+        ..docs.addAll([
+          ...toDartdoc(statement.comment),
+          ...statement.attributes.map(attributeCreator.create),
+        ])
         ..values.addAll(
           statement.enum_11.members.map(
             (e) => EnumValue(

--- a/lib/src/statements/enum_handler.dart
+++ b/lib/src/statements/enum_handler.dart
@@ -20,7 +20,6 @@ class EnumHandler extends StatementHandler {
   Spec build(Statement statement) {
     final name = db.resolveName(statement.name);
 
-    // TODO: attributes
     return Enum(
       (b) => b
         ..name = name

--- a/lib/src/statements/query_handler.dart
+++ b/lib/src/statements/query_handler.dart
@@ -1,5 +1,6 @@
 import 'package:code_builder/code_builder.dart';
 
+import '../attributes/attribute_creator.dart';
 import '../generator_database.dart';
 import '../types/type_creator.dart';
 import '../values/value_creator.dart';
@@ -13,6 +14,7 @@ class QueryHandler extends StatementHandler {
   QueryHandler(
     TypeCreator typeCreator,
     ValueCreator valueCreator,
+    AttributeCreator attributeCreator,
     GeneratorDatabase db,
   )   : resultFactoryCreator = ResultFactoryCreator(
           [
@@ -21,7 +23,7 @@ class QueryHandler extends StatementHandler {
           ],
           typeCreator,
         ),
-        super(typeCreator, valueCreator, db);
+        super(typeCreator, valueCreator, attributeCreator, db);
 
   final ResultFactoryCreator resultFactoryCreator;
 

--- a/lib/src/statements/statement_handler.dart
+++ b/lib/src/statements/statement_handler.dart
@@ -52,7 +52,6 @@ abstract class StatementHandler {
         .map((e) => _GenericFactory(e.name))
         .toList();
 
-    // TODO: attributes
     return Class((b) {
       b
         ..name = name
@@ -166,7 +165,6 @@ abstract class StatementHandler {
     final renamed = renameField(prop.name);
     final needsExplicitRename = pascalCase(renamed) != prop.name;
 
-    // TODO: attributes
     return Field(
       (b) => b
         ..type = type

--- a/lib/src/values/value_creator.dart
+++ b/lib/src/values/value_creator.dart
@@ -24,7 +24,7 @@ class ValueCreator {
       value = "'${valueRef.string.value}'";
     } else if (valueRef.hasBool_5()) {
       type = 'bool';
-      value = valueRef.bool_5.toString();
+      value = valueRef.bool_5.value.toString();
     } else {
       throw UnimplementedError('Missing handler of value $valueRef');
     }

--- a/lib/src/values/value_creator.dart
+++ b/lib/src/values/value_creator.dart
@@ -2,7 +2,6 @@ import 'package:code_builder/code_builder.dart';
 
 import '../proto/contracts.pb.dart';
 
-// TODO: split into handlers?
 class ValueCreator {
   const ValueCreator();
 

--- a/test/attribute_creator_test.dart
+++ b/test/attribute_creator_test.dart
@@ -1,0 +1,103 @@
+import 'package:contracts_generator/src/attributes/attribute_creator.dart';
+import 'package:contracts_generator/src/types/type_handler.dart';
+import 'package:contracts_generator/src/values/value_creator.dart';
+import 'package:fixnum/fixnum.dart';
+import 'package:test/scaffolding.dart';
+import 'package:test/test.dart';
+
+void main() {
+  const attributeCreator = AttributeCreator(ValueCreator());
+
+  group('AttributeCreator', () {
+    test('correctly creates @deprecated', () {
+      final noParams = AttributeRef(attributeName: 'System.ObsoleteAttribute');
+      final oneParam = AttributeRef(
+        attributeName: 'System.ObsoleteAttribute',
+        argument: [
+          AttributeArgument(
+            positional: AttributeArgument_Positional(
+              value: ValueRef(
+                string: ValueRef_String(value: 'Use something else'),
+              ),
+            ),
+          ),
+        ],
+      );
+      final twoParams = AttributeRef(
+        attributeName: 'System.ObsoleteAttribute',
+        argument: [
+          AttributeArgument(
+            positional: AttributeArgument_Positional(
+              value: ValueRef(
+                string: ValueRef_String(value: 'Use something else'),
+              ),
+            ),
+          ),
+          AttributeArgument(
+            positional: AttributeArgument_Positional(
+              value: ValueRef(
+                bool_5: ValueRef_Boolean(value: true),
+              ),
+            ),
+          ),
+        ],
+      );
+
+      expect(attributeCreator.create(noParams), '@deprecated');
+      expect(
+        attributeCreator.create(oneParam),
+        "@Deprecated('Use something else')",
+      );
+      expect(
+        attributeCreator.create(twoParams),
+        "@Deprecated('Use something else')",
+      );
+    });
+
+    test('correctly creates dartdoc', () {
+      final noParams = AttributeRef(attributeName: 'Some.Attribute');
+      final oneParam = AttributeRef(
+        attributeName: 'Some.Attribute',
+        argument: [
+          AttributeArgument(
+            positional: AttributeArgument_Positional(
+              value: ValueRef(
+                number: ValueRef_Number(value: Int64(123)),
+              ),
+            ),
+          ),
+        ],
+      );
+      final twoParams = AttributeRef(
+        attributeName: 'Some.Attribute',
+        argument: [
+          AttributeArgument(
+            positional: AttributeArgument_Positional(
+              value: ValueRef(
+                number: ValueRef_Number(value: Int64(123)),
+              ),
+            ),
+          ),
+          AttributeArgument(
+            named: AttributeArgument_Named(
+              name: 'cool',
+              value: ValueRef(
+                bool_5: ValueRef_Boolean(value: true),
+              ),
+            ),
+          ),
+        ],
+      );
+
+      expect(attributeCreator.create(noParams), '/// Some.Attribute()');
+      expect(
+        attributeCreator.create(oneParam),
+        '/// Some.Attribute(123)',
+      );
+      expect(
+        attributeCreator.create(twoParams),
+        '/// Some.Attribute(123, cool: true)',
+      );
+    });
+  });
+}


### PR DESCRIPTION
On today's weekly we have decided that attributes shall be generated as dartdoc comments since they sometimes provide useful information. However, we will hardcode support for known attributes that we have a fitting mapping for, for example `System.ObsoleteAttribute` is translated to `@deprecated`.