### PR TITLE
Remove `toJson` on generic DTOs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,9 +1,10 @@
 # Unreleased
 
-- Drop support for `json_serializable: ^4.0.0`
+- **Breaking**: Drop support for `json_serializable: ^4.0.0`
 - Allow overriding generator version with `input.override_generator_version`
 - Support `LeanCode.ContractsGenerator` `v0.1.0-alpha10`
   - Drop support for `System.decimal`
+- **Breaking**: Remove `toJson` method on generic DTOs
 
 # 0.3.0
 

--- a/example/lib/cool_name.dart
+++ b/example/lib/cool_name.dart
@@ -148,9 +148,6 @@ class PaginatedResult<TResult> with EquatableMixin {
   final int totalCount;
 
   get props => [items, totalCount];
-
-  Map<String, dynamic> toJson(Object? Function(TResult) toJsonTResult) =>
-      _$PaginatedResultToJson(this, toJsonTResult);
 }
 
 @JsonSerializable(fieldRename: FieldRename.pascal)
@@ -215,8 +212,8 @@ class EditUser
     with EquatableMixin
     implements IRemoteCommand, ISomethingRelated {
   EditUser({
-    required this.userId,
     required this.somethingId,
+    required this.userId,
     required this.list,
     required this.array,
     required this.dictionary,
@@ -226,9 +223,9 @@ class EditUser
   factory EditUser.fromJson(Map<String, dynamic> json) =>
       _$EditUserFromJson(json);
 
-  final String userId;
-
   final String somethingId;
+
+  final String userId;
 
   final List<int> list;
 
@@ -238,7 +235,7 @@ class EditUser
 
   final UserInfoDTO userInfo;
 
-  get props => [userId, somethingId, list, array, dictionary, userInfo];
+  get props => [somethingId, userId, list, array, dictionary, userInfo];
 
   Map<String, dynamic> toJson() => _$EditUserToJson(this);
   String getFullName() =>

--- a/example/lib/cool_name.g.dart
+++ b/example/lib/cool_name.g.dart
@@ -66,8 +66,8 @@ Map<String, dynamic> _$AllUsersToJson(AllUsers instance) => <String, dynamic>{
     };
 
 EditUser _$EditUserFromJson(Map<String, dynamic> json) => EditUser(
-      userId: json['UserId'] as String,
       somethingId: json['SomethingId'] as String,
+      userId: json['UserId'] as String,
       list: (json['List'] as List<dynamic>).map((e) => e as int).toList(),
       array: (json['Array'] as List<dynamic>).map((e) => e as int).toList(),
       dictionary: (json['Dictionary'] as Map<String, dynamic>).map(
@@ -78,8 +78,8 @@ EditUser _$EditUserFromJson(Map<String, dynamic> json) => EditUser(
     );
 
 Map<String, dynamic> _$EditUserToJson(EditUser instance) => <String, dynamic>{
-      'UserId': instance.userId,
       'SomethingId': instance.somethingId,
+      'UserId': instance.userId,
       'List': instance.list,
       'Array': instance.array,
       'Dictionary':

--- a/lib/src/statements/dto_handler.dart
+++ b/lib/src/statements/dto_handler.dart
@@ -19,14 +19,21 @@ class DtoHandler extends StatementHandler {
   @override
   Spec build(Statement statement) {
     return createBase(statement).rebuild((b) {
+      final typeDescriptor = statement.dto.typeDescriptor;
+
       // make it abstract if it extends a cqrs type
-      b.abstract = statement.dto.typeDescriptor.extends_1.any(db.isCqrs);
+      b.abstract = typeDescriptor.extends_1.any(db.isCqrs);
 
       if (b.abstract) {
         b
           ..annotations.clear()
           ..methods.clear()
           ..constructors.removeWhere((e) => e.name == 'fromJson');
+      }
+
+      // remove serde from generic DTOs
+      if (typeDescriptor.genericParameters.isNotEmpty) {
+        b.methods.clear();
       }
     });
   }


### PR DESCRIPTION
This was causing some overriding problems when a class would `implements` a generic DTO