### PR TITLE
Remove extra space in nullable list result factory

### DIFF
--- a/lib/src/statements/result_factory/known_result_factory_handler.dart
+++ b/lib/src/statements/result_factory/known_result_factory_handler.dart
@@ -59,7 +59,7 @@ class KnownResultFactoryHandler extends ResultFactoryHandler {
         return 'const ${jsonConverters.getConverter(typeRef)!.name}().fromJson($paramName as String$q)';
 
       case KnownType.Array:
-        return '($paramName as Iterable<dynamic>$q)$q '
+        return '($paramName as Iterable<dynamic>$q)$q'
             '.map((dynamic e) => ${ResultFactoryHandler.buildFrom(known.arguments.first, handlers, 'e')}).toList()';
 
       case KnownType.Map:


### PR DESCRIPTION
`? .` is unparsable by dart (ambiguous with the ternary condition operator). This PR removes this extra space to generate code with `?.`.