### PR TITLE
Fix duration and TimeOnly serde

### DIFF
--- a/packages/leancode_contracts/CHANGELOG.md
+++ b/packages/leancode_contracts/CHANGELOG.md
@@ -1,3 +1,8 @@
+# 0.2.0
+
+- Fix `TimeOnly` serde
+- Fix `Duration` serde
+
 # 0.1.0
 
 - Initial release

--- a/packages/leancode_contracts/lib/src/json_converters/duration_json_converter.dart
+++ b/packages/leancode_contracts/lib/src/json_converters/duration_json_converter.dart
@@ -1,3 +1,5 @@
+import 'dart:math';
+
 import 'package:json_annotation/json_annotation.dart';
 
 // TODO: while https://github.com/google/json_serializable.dart/issues/822
@@ -16,13 +18,16 @@ class DurationJsonConverter implements JsonConverter<Duration, String> {
   @override
   Duration fromJson(String json) {
     final m = _matcher.firstMatch(json)!;
+    final last = m[7] ?? '0';
+    final smallest = last.substring(0, min(6, last.length));
 
     return Duration(
           days: int.parse(m[2] ?? '0'),
           hours: int.parse(m[3]!),
           minutes: int.parse(m[4]!),
           seconds: int.parse(m[5]!),
-          microseconds: int.parse(m[7] ?? '0') ~/ 10,
+          microseconds:
+              int.parse(smallest) * pow(10, 6 - smallest.length) as int,
         ) *
         (json.startsWith('-') ? -1 : 1);
   }
@@ -33,11 +38,11 @@ class DurationJsonConverter implements JsonConverter<Duration, String> {
       return '-${toJson(-object)}';
     }
 
-    return '${object.inDays}.'
-        '${object.inHours % Duration.hoursPerDay}:'
-        '${object.inMinutes % Duration.minutesPerHour}:'
-        '${object.inSeconds % Duration.secondsPerMinute}.'
-        '${(object.inMicroseconds % Duration.microsecondsPerSecond).toString().padLeft(6, '0')}';
+    return '${object.inDays}'
+        '.${(object.inHours % Duration.hoursPerDay).toString().padLeft(2, '0')}'
+        ':${(object.inMinutes % Duration.minutesPerHour).toString().padLeft(2, '0')}'
+        ':${(object.inSeconds % Duration.secondsPerMinute).toString().padLeft(2, '0')}'
+        '.${(object.inMicroseconds % Duration.microsecondsPerSecond).toString().padLeft(6, '0')}';
   }
 }
 

--- a/packages/leancode_contracts/lib/src/types/time_only.dart
+++ b/packages/leancode_contracts/lib/src/types/time_only.dart
@@ -28,7 +28,12 @@ class TimeOnly {
   int get microsecond => source.inMicroseconds % Duration.microsecondsPerSecond;
 
   /// Serializes [TimeOnly] to a string.
-  String toJson() => const DurationJsonConverter().toJson(source);
+  String toJson() {
+    return '${hour.toString().padLeft(2, '0')}'
+        ':${minute.toString().padLeft(2, '0')}'
+        ':${second.toString().padLeft(2, '0')}'
+        '.${microsecond.toString().padLeft(6, '0')}';
+  }
 
   @override
   String toString() => source.toString();

--- a/packages/leancode_contracts/test/json_converters/duration_json_converter_test.dart
+++ b/packages/leancode_contracts/test/json_converters/duration_json_converter_test.dart
@@ -1,3 +1,55 @@
+import 'package:leancode_contracts/leancode_contracts.dart';
+import 'package:test/test.dart';
+
 void main() {
-  // TODO
+  group('DurationJsonConverter', () {
+    const conv = DurationJsonConverter();
+
+    test('serialize', () {
+      expect(conv.toJson(Duration.zero), '0.00:00:00.000000');
+      expect(
+        conv.toJson(
+          const Duration(days: 3, hours: 23, seconds: 8, microseconds: 56),
+        ),
+        '3.23:00:08.000056',
+      );
+      expect(
+        conv.toJson(
+          -const Duration(
+            days: 3,
+            hours: 23,
+            seconds: 8,
+            microseconds: 56,
+          ),
+        ),
+        '-3.23:00:08.000056',
+      );
+    });
+
+    test('deserialize', () {
+      expect(conv.fromJson('0.00:00:00.000000'), Duration.zero);
+      expect(conv.fromJson('0.00:00:00.001'), const Duration(milliseconds: 1));
+      expect(
+        conv.fromJson('0.00:00:00.000100123678'),
+        const Duration(microseconds: 100),
+      );
+      expect(
+        conv.fromJson(
+          '3.23:00:08.000056',
+        ),
+        const Duration(days: 3, hours: 23, seconds: 8, microseconds: 56),
+      );
+      expect(
+        conv.fromJson(
+          '-3.23:00:08.000056',
+        ),
+        -const Duration(
+          days: 3,
+          hours: 23,
+          seconds: 8,
+          microseconds: 56,
+        ),
+      );
+    });
+  });
 }

--- a/packages/leancode_contracts/test/types/time_only_test.dart
+++ b/packages/leancode_contracts/test/types/time_only_test.dart
@@ -42,6 +42,33 @@ void main() {
       expect(complex.microsecond, 1000);
     });
 
-    // TODO: json tests
+    test('serialization', () {
+      expect(TimeOnly(Duration.zero).toJson(), '00:00:00.000000');
+      expect(
+        TimeOnly(const Duration(days: 1) - const Duration(microseconds: 1))
+            .toJson(),
+        '23:59:59.999999',
+      );
+      expect(
+        TimeOnly(
+          const Duration(hours: 23, minutes: 32, seconds: 42, milliseconds: 1),
+        ).toJson(),
+        '23:32:42.001000',
+      );
+    });
+
+    test('deserialization', () {
+      expect(TimeOnly.fromJson('00:00:00.000000'), TimeOnly(Duration.zero));
+      expect(
+        TimeOnly.fromJson('23:59:59.999999'),
+        TimeOnly(const Duration(days: 1) - const Duration(microseconds: 1)),
+      );
+      expect(
+        TimeOnly.fromJson('23:32:42.001000'),
+        TimeOnly(
+          const Duration(hours: 23, minutes: 32, seconds: 42, milliseconds: 1),
+        ),
+      );
+    });
   });
 }

--- a/packages/leancode_contracts_generator/pubspec.yaml
+++ b/packages/leancode_contracts_generator/pubspec.yaml
@@ -24,9 +24,7 @@ dependencies:
   yaml: ^3.1.0
 
 dev_dependencies:
-  # TODO: change to hosted version once available
-  leancode_contracts:
-    path: ../leancode_contracts
+  leancode_contracts: ^0.1.0
   leancode_lint: ^1.0.2
   test: ^1.17.10
 


### PR DESCRIPTION
closes #35 

TODO: figure out whether backend rejecting TimeOnly strings with a smaller precision is expected. For reference, TimeSpan gladly parses strings with smaller precision.