### PR TITLE
Sort output statements

### DIFF
--- a/packages/leancode_contracts_generator/CHANGELOG.md
+++ b/packages/leancode_contracts_generator/CHANGELOG.md
@@ -1,6 +1,7 @@
 # Unreleased
 
 - Add verbose CLI logging under the `--verbose`/`-v` flag
+- Sort generated statements according to namespace
 
 # 0.6.1
 

--- a/packages/leancode_contracts_generator/lib/src/generator_database.dart
+++ b/packages/leancode_contracts_generator/lib/src/generator_database.dart
@@ -14,7 +14,9 @@ class GeneratorDatabase {
   @visibleForTesting
   GeneratorDatabase(this.config, this._export)
       : _statements = LinkedHashMap.fromEntries(
-          _export.statements.map((e) => MapEntry(e.name, e)),
+          _export.statements
+              .map((e) => MapEntry(e.name, e))
+              .sortedBy((e) => e.key),
         );
 
   static Future<GeneratorDatabase> fromConfig(


### PR DESCRIPTION
Still thinking how to sort fields. Alphabetical sort does not make much sense, as fields are usually grouped in a meaningful order by backend guys.