### PR TITLE
Add verbose logging to cli

### DIFF
--- a/packages/leancode_contracts_generator/CHANGELOG.md
+++ b/packages/leancode_contracts_generator/CHANGELOG.md
@@ -1,3 +1,7 @@
+# Unreleased
+
+- Add verbose CLI logging under the `--verbose`/`-v` flag
+
 # 0.6.1
 
 - Add missing result factory mapping for `DateTimeOffset`

--- a/packages/leancode_contracts_generator/bin/init_command.dart
+++ b/packages/leancode_contracts_generator/bin/init_command.dart
@@ -1,0 +1,44 @@
+import 'dart:io';
+
+import 'package:args/command_runner.dart';
+import 'package:collection/collection.dart';
+import 'package:leancode_contracts_generator/leancode_contracts_generator.dart';
+import 'package:leancode_contracts_generator/src/utils/verbose_log.dart';
+import 'package:path/path.dart' as p;
+
+import 'leancode_contracts_generator.dart';
+
+class InitCommand extends Command<int> {
+  @override
+  final name = 'init';
+  @override
+  final description = 'Initialize a config file';
+
+  @override
+  String get invocation {
+    final parents = [name];
+    for (var command = parent; command != null; command = command.parent) {
+      parents.add(command.name);
+    }
+    parents.add(runner!.executableName);
+
+    final invocation = parents.reversed.join(' ');
+    return '$invocation [directory (default: .)]';
+  }
+
+  @override
+  Future<int> run() async {
+    final dir = argResults!.rest.firstOrNull ?? '.';
+    final verbose = globalResults!.verbose;
+
+    final done = verboseLog(
+      message: 'Initializing config file in $dir',
+      verbose: verbose,
+    );
+    await File(p.join(dir, configFileName))
+        .writeAsString(ContractsGeneratorConfig.defaultYamlConfig);
+    done();
+
+    return 0;
+  }
+}

--- a/packages/leancode_contracts_generator/bin/leancode_contracts_generator.dart
+++ b/packages/leancode_contracts_generator/bin/leancode_contracts_generator.dart
@@ -1,81 +1,85 @@
 import 'dart:io';
 
+import 'package:args/args.dart';
 import 'package:args/command_runner.dart';
-import 'package:collection/collection.dart';
 import 'package:leancode_contracts_generator/leancode_contracts_generator.dart';
-import 'package:path/path.dart' as p;
+
+import 'init_command.dart';
 
 const configFileName = 'contracts_generator.yaml';
+const verboseFlag = 'verbose';
 
 Future<void> main(List<String> arguments) async {
-  final initCommand = InitCommand();
-  final runner = CommandRunner<void>(
-    'leancode_contracts_generator',
-    'Command line utility for generating dart CQRS contracts',
-  )..addCommand(initCommand);
+  final runner = GeneratorCommandRunner();
 
   try {
-    if (arguments.isEmpty) {
-      final configFile = File(configFileName);
-      if (!configFile.existsSync()) {
-        fatalError(
-          'No $configFileName config file found in the current directory. Did you run `${runner.executableName} ${initCommand.name}`?',
-        );
-      }
-
-      final generator = ContractsGenerator(
-        ContractsGeneratorConfig.fromYaml(await configFile.readAsString()),
-      );
-
-      await generator.writeAll();
-      exit(0);
-    }
-
-    await runner.run(arguments);
+    final statusCode = await runner.run(arguments) ?? 0;
+    exit(statusCode);
   } on ContractsGeneratorException catch (err) {
-    fatalError(err.message);
+    printError(err.message);
   } catch (err, st) {
     stderr
       ..writeln(err)
       ..writeln(st);
-    fatalError(
+    printError(
       'An unknown error occurred, this is most likely a bug. '
       'Please consider reporting it with the above error.',
     );
   }
-}
-
-class InitCommand extends Command<void> {
-  @override
-  final name = 'init';
-  @override
-  final description = 'Initialize a config file';
-
-  @override
-  String get invocation {
-    final parents = [name];
-    for (var command = parent; command != null; command = command.parent) {
-      parents.add(command.name);
-    }
-    parents.add(runner!.executableName);
-
-    final invocation = parents.reversed.join(' ');
-    return '$invocation [directory (default: .)]';
-  }
-
-  @override
-  Future<void> run() async {
-    final dir = argResults!.rest.firstOrNull ?? '.';
-
-    await File(p.join(dir, configFileName))
-        .writeAsString(ContractsGeneratorConfig.defaultYamlConfig);
-
-    exit(0);
-  }
-}
-
-Never fatalError(String message) {
-  stderr.writeln('\x1B[31m$message\x1B[0m');
 
   exit(1);
+}
+
+class GeneratorCommandRunner extends CommandRunner<int> {
+  GeneratorCommandRunner()
+      : _initCommand = InitCommand(),
+        super(
+          'leancode_contracts_generator',
+          'Command line utility for generating dart CQRS contracts',
+        ) {
+    addCommand(_initCommand);
+
+    argParser.addFlag(
+      verboseFlag,
+      abbr: 'v',
+      help: 'Increase logging.',
+      negatable: false,
+    );
+  }
+
+  final InitCommand _initCommand;
+
+  @override
+  Future<int?> run(Iterable<String> args) async {
+    final parsedArgs = argParser.parse(args);
+    final verbose = parsedArgs.verbose;
+
+    if (parsedArgs.command == null) {
+      final configFile = File(configFileName);
+      if (!configFile.existsSync()) {
+        printError(
+          'No $configFileName config file found in the current directory. Did you run `$executableName ${_initCommand.name}`?',
+        );
+        return 1;
+      }
+
+      final generator = ContractsGenerator(
+        ContractsGeneratorConfig.fromYaml(await configFile.readAsString()),
+        verbose: verbose,
+      );
+
+      await generator.writeAll();
+      return 0;
+    }
+
+    return super.run(args);
+  }
+}
+
+void printError(String message) {
+  stderr.writeln('\x1B[31m$message\x1B[0m');
+}
+
+extension ArgResultsX on ArgResults {
+  bool get verbose => this[verboseFlag] as bool;
 }

--- a/packages/leancode_contracts_generator/lib/src/utils/verbose_log.dart
+++ b/packages/leancode_contracts_generator/lib/src/utils/verbose_log.dart
@@ -1,0 +1,18 @@
+import 'dart:io';
+
+import 'package:meta/meta.dart';
+
+@useResult
+void Function() verboseLog({required String message, required bool verbose}) {
+  if (!verbose) {
+    return () {};
+  }
+
+  final sw = Stopwatch()..start();
+
+  stdout.write('$message. ');
+
+  return () {
+    stdout.writeln('Done in ${sw.elapsed}');
+  };
+}


### PR DESCRIPTION
Inspired by reading maestro code. Added some very basic logging.

I'm happy to report that generating dart code takes about 200ms on my machine (non AOT). Most of the time is spent on (in that order):

1. generating json_serializable code
2. interpreter/VM dart startup
3. backend generator


By removing json_serializable generation, I might be able to enable AOT compilation. Which will effectively remove point 1 and 2.