### PR TITLE
Use Equatable as a mixin instead of deprecated EquatableMixin

### DIFF
--- a/packages/leancode_contracts/CHANGELOG.md
+++ b/packages/leancode_contracts/CHANGELOG.md
@@ -1,3 +1,7 @@
+# 0.9.0
+
+- **BREAKING**: change the `package:equatable` constraint to `"^2.1.0"`, which deprecates `EquatableMixin` in favor of using `Equatable` as a mixin
+
 # 0.8.0
 
 - **BREAKING**: change the `pacakge:cqrs` constraint to `">=9.0.0 <11.0.0"`

--- a/packages/leancode_contracts/pubspec.yaml
+++ b/packages/leancode_contracts/pubspec.yaml
@@ -1,14 +1,14 @@
 name: leancode_contracts
 repository: https://github.com/leancodepl/contractsgenerator-dart
 description: Dart contracts runtime for a CQRS API.
-version: 0.8.0
+version: 0.9.0
 
 environment:
   sdk: ">=3.0.0 <4.0.0"
 
 dependencies:
   cqrs: ^10.0.2
-  equatable: ^2.0.3
+  equatable: ^2.1.0
   json_annotation: ^4.6.0
 
 dev_dependencies:

--- a/packages/leancode_contracts_generator/CHANGELOG.md
+++ b/packages/leancode_contracts_generator/CHANGELOG.md
@@ -1,3 +1,7 @@
+# 0.18.0
+
+- **BREAKING**: Generate `with Equatable` instead of the deprecated `with EquatableMixin`. Requires `package:leancode_contracts` v0.9.0 (`package:equatable` v2.1.0)
+
 # 0.17.1
 
 - Include fully qualified names in Query/Command/Topic/Operation classes as a static `fullName$` field

--- a/packages/leancode_contracts_generator/example/lib/cool_name.dart
+++ b/packages/leancode_contracts_generator/example/lib/cool_name.dart
@@ -7,7 +7,7 @@ part 'cool_name.g.dart';
 // :)
 
 @ContractsSerializable()
-class Auth with EquatableMixin {
+class Auth with Equatable {
   Auth();
 
   factory Auth.fromJson(Map<String, dynamic> json) => _$AuthFromJson(json);
@@ -21,7 +21,7 @@ class Auth with EquatableMixin {
 }
 
 @ContractsSerializable()
-class KnownClaims with EquatableMixin {
+class KnownClaims with Equatable {
   KnownClaims();
 
   factory KnownClaims.fromJson(Map<String, dynamic> json) =>
@@ -40,7 +40,7 @@ class KnownClaims with EquatableMixin {
 }
 
 @ContractsSerializable()
-class Roles with EquatableMixin {
+class Roles with Equatable {
   Roles();
 
   factory Roles.fromJson(Map<String, dynamic> json) => _$RolesFromJson(json);
@@ -61,7 +61,7 @@ class Roles with EquatableMixin {
 
 /// This is a class-level comment.
 abstract class PaginatedQuery<TResult>
-    with EquatableMixin
+    with Equatable
     implements Query<PaginatedResult<TResult>> {
   PaginatedQuery({required this.pageNumber, required this.pageSize});
 
@@ -75,7 +75,7 @@ abstract class PaginatedQuery<TResult>
 
 /// This one is in XML.
 @ContractsSerializable(genericArgumentFactories: true)
-class PaginatedResult<TResult> with EquatableMixin {
+class PaginatedResult<TResult> with Equatable {
   PaginatedResult({required this.items, required this.totalCount});
 
   factory PaginatedResult.fromJson(
@@ -95,7 +95,7 @@ class PaginatedResult<TResult> with EquatableMixin {
 }
 
 @ContractsSerializable()
-class ISomethingRelated with EquatableMixin {
+class ISomethingRelated with Equatable {
   ISomethingRelated({required this.somethingId});
 
   factory ISomethingRelated.fromJson(Map<String, dynamic> json) =>
@@ -114,7 +114,7 @@ class ISomethingRelated with EquatableMixin {
 /// System.Diagnostics.CodeAnalysis.SuppressMessageAttribute('?', 'SA1302', Justification: 'Convention for authorizers.')
 /// System.Diagnostics.CodeAnalysis.SuppressMessageAttribute('?', 'IDE1006', Justification: 'Convention for authorizers.')
 @ContractsSerializable()
-class WhenHasSomethingAccess with EquatableMixin {
+class WhenHasSomethingAccess with Equatable {
   WhenHasSomethingAccess();
 
   factory WhenHasSomethingAccess.fromJson(Map<String, dynamic> json) =>
@@ -130,7 +130,7 @@ class WhenHasSomethingAccess with EquatableMixin {
 
 /// LeanCode.Contracts.Security.AuthorizeWhenHasAnyOfAttribute('admin')
 @ContractsSerializable()
-class AllUsers with EquatableMixin implements PaginatedQuery<UserInfoDTO> {
+class AllUsers with Equatable implements PaginatedQuery<UserInfoDTO> {
   AllUsers({required this.pageNumber, required this.pageSize});
 
   factory AllUsers.fromJson(Map<String, dynamic> json) =>
@@ -159,7 +159,7 @@ class AllUsers with EquatableMixin implements PaginatedQuery<UserInfoDTO> {
 /// LeanCode.Contracts.Security.AuthorizeWhenHasAnyOfAttribute('admin')
 /// LeanCode.ContractsGeneratorV2.ExampleContracts.Security.AuthorizeWhenHasSomethingAccessAttribute()
 @ContractsSerializable()
-class EditUser with EquatableMixin implements Command, ISomethingRelated {
+class EditUser with Equatable implements Command, ISomethingRelated {
   EditUser({
     required this.somethingId,
     required this.userId,
@@ -227,7 +227,7 @@ class EditUserErrorCodes {
 
 /// LeanCode.Contracts.Security.AuthorizeWhenHasAnyOfAttribute('admin')
 @ContractsSerializable()
-class UserById with EquatableMixin implements Query<UserInfoDTO?> {
+class UserById with Equatable implements Query<UserInfoDTO?> {
   UserById();
 
   factory UserById.fromJson(Map<String, dynamic> json) =>
@@ -249,7 +249,7 @@ class UserById with EquatableMixin implements Query<UserInfoDTO?> {
 
 @Deprecated('Use something else instead')
 @ContractsSerializable()
-class UserInfoDTO with EquatableMixin {
+class UserInfoDTO with Equatable {
   UserInfoDTO({
     required this.firstname,
     required this.surname,
@@ -279,7 +279,7 @@ class UserInfoDTO with EquatableMixin {
 
 /// LeanCode.Contracts.Security.AuthorizeWhenHasAnyOfAttribute('admin')
 @ContractsSerializable()
-class UserSomething with EquatableMixin implements Query<int?> {
+class UserSomething with Equatable implements Query<int?> {
   UserSomething();
 
   factory UserSomething.fromJson(Map<String, dynamic> json) =>

--- a/packages/leancode_contracts_generator/example/lib/data/contracts.dart
+++ b/packages/leancode_contracts_generator/example/lib/data/contracts.dart
@@ -6,7 +6,7 @@ part 'contracts.g.dart';
 
 /// LeanCode.Contracts.Security.AllowUnauthorizedAttribute()
 @ContractsSerializable()
-class Command_ with EquatableMixin implements Command {
+class Command_ with Equatable implements Command {
   Command_();
 
   factory Command_.fromJson(Map<String, dynamic> json) =>
@@ -25,7 +25,7 @@ class CommandErrorCodes {}
 
 /// LeanCode.Contracts.Security.AllowUnauthorizedAttribute()
 @ContractsSerializable()
-class Query_ with EquatableMixin implements Query<int> {
+class Query_ with Equatable implements Query<int> {
   Query_();
 
   factory Query_.fromJson(Map<String, dynamic> json) => _$Query_FromJson(json);
@@ -42,7 +42,7 @@ class Query_ with EquatableMixin implements Query<int> {
 }
 
 @ContractsSerializable()
-class Notification with EquatableMixin implements TopicNotification {
+class Notification with Equatable implements TopicNotification {
   Notification();
 
   factory Notification.fromJson(Map<String, dynamic> json) =>
@@ -56,7 +56,7 @@ class Notification with EquatableMixin implements TopicNotification {
 }
 
 @ContractsSerializable()
-class Topic_ with EquatableMixin implements Topic<TopicNotification> {
+class Topic_ with Equatable implements Topic<TopicNotification> {
   Topic_();
 
   factory Topic_.fromJson(Map<String, dynamic> json) => _$Topic_FromJson(json);

--- a/packages/leancode_contracts_generator/lib/src/statements/statement_handler.dart
+++ b/packages/leancode_contracts_generator/lib/src/statements/statement_handler.dart
@@ -159,7 +159,7 @@ abstract class StatementHandler {
         ..implements.addAll(
           db.getImplementingNotifications(statement.name).map(refer),
         )
-        ..mixins.add(refer('EquatableMixin'));
+        ..mixins.add(refer('Equatable'));
     });
   }
 

--- a/packages/leancode_contracts_generator/pubspec.yaml
+++ b/packages/leancode_contracts_generator/pubspec.yaml
@@ -1,7 +1,7 @@
 name: leancode_contracts_generator
 repository: https://github.com/leancodepl/contractsgenerator-dart
 description: Dart contracts client generator for a CQRS API.
-version: 0.17.1
+version: 0.18.0
 
 environment:
   sdk: ">=3.8.0 <4.0.0"


### PR DESCRIPTION
equatable 2.1.0 turns `Equatable` into an `abstract mixin class` and deprecates `EquatableMixin` with the message _"use Equatable as a mixin instead"_.

Without this change, contracts generated by this package emit a `deprecated_member_use` info on every class, which breaks consumers running `dart analyze --fatal-infos` over their generated contracts.

## Changes

- **`leancode_contracts`** — bump the `package:equatable` constraint from `^2.0.3` to `^2.1.0`, version `0.8.0` → `0.9.0`
- **`leancode_contracts_generator`** — emit `with Equatable` instead of `with EquatableMixin` (`statement_handler.dart`), version `0.17.1` → `0.18.0`
- Regenerated the example contracts (16 classes across `example/lib/cool_name.dart` and `example/lib/data/contracts.dart`)
- CHANGELOG entries for both packages

Generated code now requires `leancode_contracts` v0.9.0, since older versions can resolve to equatable 2.0.x where `Equatable` is not usable as a mixin — hence the breaking-minor bumps on both packages. Happy to drop the version bumps if you'd rather handle them in a separate release PR.

## Verification

Ran every CI step locally on the pinned SDK versions (Dart 3.5.4 for `leancode_contracts`, Dart 3.8.3 + .NET 8 for the generator):

| Step | `leancode_contracts` | `leancode_contracts_generator` |
| --- | --- | --- |
| `dart pub get` | ✅ resolves `equatable 2.1.0` | ✅ |
| `dart format --set-exit-if-changed` | ✅ 0 changed | ✅ 0 of 56 changed |
| `dart analyze --fatal-warnings --fatal-infos` | ✅ No issues | ✅ No issues |
| `dart test` | ✅ 47 passed | ✅ 79 passed |
| `dart pub publish --dry-run` | ✅ 0 warnings | ✅ 0 warnings |

The 79 generator tests include the full integration suite, which for each contract script runs the .NET generator, emits Dart, runs `build_runner` for `json_serializable`, then compiles and executes the result — so the `with Equatable` output is compiled end-to-end.

Both example files were deleted and regenerated with the real generator to confirm they are byte-identical to what is committed here.

## Unrelated pre-existing issue

`leancode_contracts` pins `leancode_lint: ^14.3.0`, which cannot resolve on any modern SDK (it needs the removed `_macros` package; it fails on Dart 3.12). It works today only because CI pins 3.5.4. Out of scope here, but it will block the next SDK bump.

---
_Generated by [Claude Code](https://claude.ai/code/session_01MnwQKwZ15T4fqsVdnyXzah)_