### PR TITLE
Fix generating toJson for queries/commands/operations/topics implementing generic interfaces

### DIFF
--- a/packages/leancode_contracts_generator/example/ExampleContracts/Pagination/ForwardedGenericImplementers.cs
+++ b/packages/leancode_contracts_generator/example/ExampleContracts/Pagination/ForwardedGenericImplementers.cs
@@ -1,0 +1,42 @@
+namespace LeanCode.ContractsGeneratorV2.ExampleContracts.Pagination
+{
+    // Generic implementers that forward their own type variable across several
+    // generic bases: the single `toJson` must override every base and pass the
+    // child's factory to `_$...ToJson`. Interfaces reused from
+    // MultiGenericInterface.cs.
+
+    // `T` is at position 0 in IFirstFacet, position 1 in IPairFacet. It is
+    // forwarded from position 1 (where every base agrees on `T`); position 0
+    // clashes with the concrete `User`, so it is an unused `Never` slot.
+    public class ForwardedAtSecondPosition<T> : IFirstFacet<T>, IPairFacet<User, T>
+    {
+        public T First { get; set; }
+        public User Left { get; set; }
+        public T Right { get; set; }
+    }
+
+    // `T` clashes with a concrete `User` at position 0, so no position forwards
+    // it: position 0 is a `Never` slot and `T` is appended as an extra parameter.
+    public class ForwardedVarWithConcreteClash<T> : IFirstFacet<T>, ISecondFacet<User>
+    {
+        public T First { get; set; }
+        public User Second { get; set; }
+    }
+
+    // Two variables clashing at position 0: it becomes `Never` and both are
+    // appended as extra parameters.
+    public class TwoForwardedVars<A, B> : IFirstFacet<A>, ISecondFacet<B>
+    {
+        public A First { get; set; }
+        public B Second { get; set; }
+    }
+
+    // `T` bound at both positions of one base. It is forwarded from position 0;
+    // position 1 must be an unused `Never` slot, otherwise the override would
+    // emit two parameters named `toJsonT`.
+    public class VarBoundTwice<T> : IPairFacet<T, T>
+    {
+        public T Left { get; set; }
+        public T Right { get; set; }
+    }
+}

--- a/packages/leancode_contracts_generator/example/ExampleContracts/Pagination/MultiGenericInterface.cs
+++ b/packages/leancode_contracts_generator/example/ExampleContracts/Pagination/MultiGenericInterface.cs
@@ -1,0 +1,54 @@
+namespace LeanCode.ContractsGeneratorV2.ExampleContracts.Pagination
+{
+    // A concrete DTO implementing several generic interfaces at once (C# allows
+    // only one base class). Each interface generates a factory-taking `toJson`,
+    // and the single `toJson` on the implementer must override all of them.
+    // `PaginatedResult<TResult>`/`User` are reused from the sibling examples.
+    public interface IFirstFacet<TFirst>
+    {
+        TFirst First { get; set; }
+    }
+
+    public interface ISecondFacet<TSecond>
+    {
+        TSecond Second { get; set; }
+    }
+
+    public interface IPairFacet<TLeft, TRight>
+    {
+        TLeft Left { get; set; }
+        TRight Right { get; set; }
+    }
+
+    // Two arity-1 interfaces binding the same type at position 0.
+    public class SameFacets : IFirstFacet<User>, ISecondFacet<User>
+    {
+        public User First { get; set; }
+        public User Second { get; set; }
+    }
+
+    // Interfaces binding different types at position 0: this is what forces the
+    // unused slot to be `Object? Function(Never)?` — no single concrete type
+    // could override both.
+    public class MixedFacets : IFirstFacet<User>, ISecondFacet<PaginatedResult<User>>
+    {
+        public User First { get; set; }
+        public PaginatedResult<User> Second { get; set; }
+    }
+
+    // Bases of different arity: the override widens to the largest (2).
+    public class DifferentArityFacets : IFirstFacet<User>, IPairFacet<User, PaginatedResult<User>>
+    {
+        public User First { get; set; }
+        public User Left { get; set; }
+        public PaginatedResult<User> Right { get; set; }
+    }
+
+    // Different arity and different types at position 0 (the arity-2 `Never` case).
+    public class ClashingArityFacets : IFirstFacet<User>, IPairFacet<PaginatedResult<User>, User>
+    {
+        public User First { get; set; }
+        public PaginatedResult<User> Left { get; set; }
+        public User Right { get; set; }
+    }
+}

--- a/packages/leancode_contracts_generator/example/ExampleContracts/Pagination/SharedInterfaceQueries.cs
+++ b/packages/leancode_contracts_generator/example/ExampleContracts/Pagination/SharedInterfaceQueries.cs
@@ -1,0 +1,26 @@
+using LeanCode.Contracts;
+
+namespace LeanCode.ContractsGeneratorV2.ExampleContracts.Pagination
+{
+    // A non-DTO statement (here: a query) implementing a generic interface also
+    // needs the `toJson` override, and gets it via `createBase` like any DTO.
+    public interface IFacetQuery<TFacet>
+    {
+        TFacet Facet { get; set; }
+    }
+
+    // Query + one generic interface: arity-1 override.
+    public class FacetQueryUser : IQuery<int?>, IFacetQuery<User>
+    {
+        public User Facet { get; set; }
+    }
+
+    // Query combining the shared interface with a 2-arity one: the override is
+    // arity 2, so the shared interface doesn't force a single arity.
+    public class FacetQueryCombined : IQuery<bool>, IFacetQuery<User>, IPairFacet<User, PaginatedResult<User>>
+    {
+        public User Facet { get; set; }
+        public User Left { get; set; }
+        public PaginatedResult<User> Right { get; set; }
+    }
+}

--- a/packages/leancode_contracts_generator/example/lib/cool_name.dart
+++ b/packages/leancode_contracts_generator/example/lib/cool_name.dart
@@ -114,7 +114,7 @@ class AllUsersResult with Equatable implements PaginatedResult<User> {
 
   List<Object?> get props => [items, totalCount];
 
-  Map<String, dynamic> toJson([Object? Function(User)? _]) =>
+  Map<String, dynamic> toJson([Object? Function(Never)? _]) =>
       _$AllUsersResultToJson(this);
 }
 
@@ -148,6 +148,312 @@ class ChildResult<T> with Equatable implements PaginatedResult<T> {
 }
 
 @ContractsSerializable()
+class ClashingArityFacets
+    with Equatable
+    implements IFirstFacet<User>, IPairFacet<PaginatedResult<User>, User> {
+  ClashingArityFacets({
+    required this.first,
+    required this.left,
+    required this.right,
+  });
+
+  factory ClashingArityFacets.fromJson(Map<String, dynamic> json) =>
+      _$ClashingArityFacetsFromJson(json);
+
+  final User first;
+
+  final PaginatedResult<User> left;
+
+  final User right;
+
+  static const fullName$ =
+      'LeanCode.ContractsGeneratorV2.ExampleContracts.Pagination.ClashingArityFacets';
+
+  List<Object?> get props => [first, left, right];
+
+  Map<String, dynamic> toJson([
+    Object? Function(Never)? _,
+    Object? Function(Never)? _,
+  ]) => _$ClashingArityFacetsToJson(this);
+}
+
+@ContractsSerializable()
+class DifferentArityFacets
+    with Equatable
+    implements IFirstFacet<User>, IPairFacet<User, PaginatedResult<User>> {
+  DifferentArityFacets({
+    required this.first,
+    required this.left,
+    required this.right,
+  });
+
+  factory DifferentArityFacets.fromJson(Map<String, dynamic> json) =>
+      _$DifferentArityFacetsFromJson(json);
+
+  final User first;
+
+  final User left;
+
+  final PaginatedResult<User> right;
+
+  static const fullName$ =
+      'LeanCode.ContractsGeneratorV2.ExampleContracts.Pagination.DifferentArityFacets';
+
+  List<Object?> get props => [first, left, right];
+
+  Map<String, dynamic> toJson([
+    Object? Function(Never)? _,
+    Object? Function(Never)? _,
+  ]) => _$DifferentArityFacetsToJson(this);
+}
+
+@ContractsSerializable()
+class FacetQueryCombined
+    with Equatable
+    implements
+        Query<bool>,
+        IFacetQuery<User>,
+        IPairFacet<User, PaginatedResult<User>> {
+  FacetQueryCombined({
+    required this.facet,
+    required this.left,
+    required this.right,
+  });
+
+  factory FacetQueryCombined.fromJson(Map<String, dynamic> json) =>
+      _$FacetQueryCombinedFromJson(json);
+
+  final User facet;
+
+  final User left;
+
+  final PaginatedResult<User> right;
+
+  static const fullName$ =
+      'LeanCode.ContractsGeneratorV2.ExampleContracts.Pagination.FacetQueryCombined';
+
+  List<Object?> get props => [facet, left, right];
+
+  Map<String, dynamic> toJson([
+    Object? Function(Never)? _,
+    Object? Function(Never)? _,
+  ]) => _$FacetQueryCombinedToJson(this);
+
+  bool resultFactory(dynamic decodedJson) => decodedJson as bool;
+
+  String getFullName() => fullName$;
+}
+
+@ContractsSerializable()
+class FacetQueryUser with Equatable implements Query<int?>, IFacetQuery<User> {
+  FacetQueryUser({required this.facet});
+
+  factory FacetQueryUser.fromJson(Map<String, dynamic> json) =>
+      _$FacetQueryUserFromJson(json);
+
+  final User facet;
+
+  static const fullName$ =
+      'LeanCode.ContractsGeneratorV2.ExampleContracts.Pagination.FacetQueryUser';
+
+  List<Object?> get props => [facet];
+
+  Map<String, dynamic> toJson([Object? Function(Never)? _]) =>
+      _$FacetQueryUserToJson(this);
+
+  int? resultFactory(dynamic decodedJson) => decodedJson as int?;
+
+  String getFullName() => fullName$;
+}
+
+@ContractsSerializable(genericArgumentFactories: true)
+class ForwardedAtSecondPosition<T>
+    with Equatable
+    implements IFirstFacet<T>, IPairFacet<User, T> {
+  ForwardedAtSecondPosition({
+    required this.first,
+    required this.left,
+    required this.right,
+  });
+
+  factory ForwardedAtSecondPosition.fromJson(
+    Map<String, dynamic> json,
+    T Function(Object?) fromJsonT,
+  ) => _$ForwardedAtSecondPositionFromJson(json, fromJsonT);
+
+  final T first;
+
+  final User left;
+
+  final T right;
+
+  static const fullName$ =
+      'LeanCode.ContractsGeneratorV2.ExampleContracts.Pagination.ForwardedAtSecondPosition';
+
+  List<Object?> get props => [first, left, right];
+
+  Map<String, dynamic> toJson([
+    Object? Function(Never)? _,
+    Object? Function(T)? toJsonT,
+  ]) => _$ForwardedAtSecondPositionToJson(this, toJsonT ?? ((v) => v));
+}
+
+@ContractsSerializable(genericArgumentFactories: true)
+class ForwardedVarWithConcreteClash<T>
+    with Equatable
+    implements IFirstFacet<T>, ISecondFacet<User> {
+  ForwardedVarWithConcreteClash({required this.first, required this.second});
+
+  factory ForwardedVarWithConcreteClash.fromJson(
+    Map<String, dynamic> json,
+    T Function(Object?) fromJsonT,
+  ) => _$ForwardedVarWithConcreteClashFromJson(json, fromJsonT);
+
+  final T first;
+
+  final User second;
+
+  static const fullName$ =
+      'LeanCode.ContractsGeneratorV2.ExampleContracts.Pagination.ForwardedVarWithConcreteClash';
+
+  List<Object?> get props => [first, second];
+
+  Map<String, dynamic> toJson([
+    Object? Function(Never)? _,
+    Object? Function(T)? toJsonT,
+  ]) => _$ForwardedVarWithConcreteClashToJson(this, toJsonT ?? ((v) => v));
+}
+
+@ContractsSerializable(genericArgumentFactories: true)
+class IFacetQuery<TFacet> with Equatable {
+  IFacetQuery({required this.facet});
+
+  factory IFacetQuery.fromJson(
+    Map<String, dynamic> json,
+    TFacet Function(Object?) fromJsonTFacet,
+  ) => _$IFacetQueryFromJson(json, fromJsonTFacet);
+
+  final TFacet facet;
+
+  static const fullName$ =
+      'LeanCode.ContractsGeneratorV2.ExampleContracts.Pagination.IFacetQuery';
+
+  List<Object?> get props => [facet];
+
+  Map<String, dynamic> toJson(Object? Function(TFacet) toJsonTFacet) =>
+      _$IFacetQueryToJson(this, toJsonTFacet);
+}
+
+@ContractsSerializable(genericArgumentFactories: true)
+class IFirstFacet<TFirst> with Equatable {
+  IFirstFacet({required this.first});
+
+  factory IFirstFacet.fromJson(
+    Map<String, dynamic> json,
+    TFirst Function(Object?) fromJsonTFirst,
+  ) => _$IFirstFacetFromJson(json, fromJsonTFirst);
+
+  final TFirst first;
+
+  static const fullName$ =
+      'LeanCode.ContractsGeneratorV2.ExampleContracts.Pagination.IFirstFacet';
+
+  List<Object?> get props => [first];
+
+  Map<String, dynamic> toJson(Object? Function(TFirst) toJsonTFirst) =>
+      _$IFirstFacetToJson(this, toJsonTFirst);
+}
+
+@ContractsSerializable(genericArgumentFactories: true)
+class IPairFacet<TLeft, TRight> with Equatable {
+  IPairFacet({required this.left, required this.right});
+
+  factory IPairFacet.fromJson(
+    Map<String, dynamic> json,
+    TLeft Function(Object?) fromJsonTLeft,
+    TRight Function(Object?) fromJsonTRight,
+  ) => _$IPairFacetFromJson(json, fromJsonTLeft, fromJsonTRight);
+
+  final TLeft left;
+
+  final TRight right;
+
+  static const fullName$ =
+      'LeanCode.ContractsGeneratorV2.ExampleContracts.Pagination.IPairFacet';
+
+  List<Object?> get props => [left, right];
+
+  Map<String, dynamic> toJson(
+    Object? Function(TLeft) toJsonTLeft,
+    Object? Function(TRight) toJsonTRight,
+  ) => _$IPairFacetToJson(this, toJsonTLeft, toJsonTRight);
+}
+
+@ContractsSerializable(genericArgumentFactories: true)
+class ISecondFacet<TSecond> with Equatable {
+  ISecondFacet({required this.second});
+
+  factory ISecondFacet.fromJson(
+    Map<String, dynamic> json,
+    TSecond Function(Object?) fromJsonTSecond,
+  ) => _$ISecondFacetFromJson(json, fromJsonTSecond);
+
+  final TSecond second;
+
+  static const fullName$ =
+      'LeanCode.ContractsGeneratorV2.ExampleContracts.Pagination.ISecondFacet';
+
+  List<Object?> get props => [second];
+
+  Map<String, dynamic> toJson(Object? Function(TSecond) toJsonTSecond) =>
+      _$ISecondFacetToJson(this, toJsonTSecond);
+}
+
+@ContractsSerializable()
+class MixedFacets
+    with Equatable
+    implements IFirstFacet<User>, ISecondFacet<PaginatedResult<User>> {
+  MixedFacets({required this.first, required this.second});
+
+  factory MixedFacets.fromJson(Map<String, dynamic> json) =>
+      _$MixedFacetsFromJson(json);
+
+  final User first;
+
+  final PaginatedResult<User> second;
+
+  static const fullName$ =
+      'LeanCode.ContractsGeneratorV2.ExampleContracts.Pagination.MixedFacets';
+
+  List<Object?> get props => [first, second];
+
+  Map<String, dynamic> toJson([Object? Function(Never)? _]) =>
+      _$MixedFacetsToJson(this);
+}
+
+@ContractsSerializable()
+class SameFacets
+    with Equatable
+    implements IFirstFacet<User>, ISecondFacet<User> {
+  SameFacets({required this.first, required this.second});
+
+  factory SameFacets.fromJson(Map<String, dynamic> json) =>
+      _$SameFacetsFromJson(json);
+
+  final User first;
+
+  final User second;
+
+  static const fullName$ =
+      'LeanCode.ContractsGeneratorV2.ExampleContracts.Pagination.SameFacets';
+
+  List<Object?> get props => [first, second];
+
+  Map<String, dynamic> toJson([Object? Function(Never)? _]) =>
+      _$SameFacetsToJson(this);
+}
+
+@ContractsSerializable()
 class SearchResponse with Equatable {
   SearchResponse({
     required this.page,
@@ -172,6 +478,38 @@ class SearchResponse with Equatable {
   Map<String, dynamic> toJson() => _$SearchResponseToJson(this);
 }
 
+@ContractsSerializable(genericArgumentFactories: true)
+class TwoForwardedVars<A, B>
+    with Equatable
+    implements IFirstFacet<A>, ISecondFacet<B> {
+  TwoForwardedVars({required this.first, required this.second});
+
+  factory TwoForwardedVars.fromJson(
+    Map<String, dynamic> json,
+    A Function(Object?) fromJsonA,
+    B Function(Object?) fromJsonB,
+  ) => _$TwoForwardedVarsFromJson(json, fromJsonA, fromJsonB);
+
+  final A first;
+
+  final B second;
+
+  static const fullName$ =
+      'LeanCode.ContractsGeneratorV2.ExampleContracts.Pagination.TwoForwardedVars';
+
+  List<Object?> get props => [first, second];
+
+  Map<String, dynamic> toJson([
+    Object? Function(Never)? _,
+    Object? Function(A)? toJsonA,
+    Object? Function(B)? toJsonB,
+  ]) => _$TwoForwardedVarsToJson(
+    this,
+    toJsonA ?? ((v) => v),
+    toJsonB ?? ((v) => v),
+  );
+}
+
 @ContractsSerializable()
 class User with Equatable {
   User({required this.id, required this.name});
@@ -188,6 +526,30 @@ class User with Equatable {
   List<Object?> get props => [id, name];
 
   Map<String, dynamic> toJson() => _$UserToJson(this);
+}
+
+@ContractsSerializable(genericArgumentFactories: true)
+class VarBoundTwice<T> with Equatable implements IPairFacet<T, T> {
+  VarBoundTwice({required this.left, required this.right});
+
+  factory VarBoundTwice.fromJson(
+    Map<String, dynamic> json,
+    T Function(Object?) fromJsonT,
+  ) => _$VarBoundTwiceFromJson(json, fromJsonT);
+
+  final T left;
+
+  final T right;
+
+  static const fullName$ =
+      'LeanCode.ContractsGeneratorV2.ExampleContracts.Pagination.VarBoundTwice';
+
+  List<Object?> get props => [left, right];
+
+  Map<String, dynamic> toJson([
+    Object? Function(T)? toJsonT,
+    Object? Function(Never)? _,
+  ]) => _$VarBoundTwiceToJson(this, toJsonT ?? ((v) => v));
 }
 
 @ContractsSerializable()
@@ -241,7 +603,8 @@ class AllUsers with Equatable implements PaginatedQuery<UserInfoDTO> {
 
   List<Object?> get props => [pageNumber, pageSize];
 
-  Map<String, dynamic> toJson() => _$AllUsersToJson(this);
+  Map<String, dynamic> toJson([Object? Function(Never)? _]) =>
+      _$AllUsersToJson(this);
 
   PaginatedResult<UserInfoDTO> resultFactory(dynamic decodedJson) =>
       _$PaginatedResultFromJson(

--- a/packages/leancode_contracts_generator/example/lib/cool_name.g.dart
+++ b/packages/leancode_contracts_generator/example/lib/cool_name.g.dart
@@ -67,6 +67,170 @@ Map<String, dynamic> _$ChildResultToJson<T>(
   'Extras': instance.extras.map(toJsonT).toList(),
 };
 
+ClashingArityFacets _$ClashingArityFacetsFromJson(Map<String, dynamic> json) =>
+    ClashingArityFacets(
+      first: User.fromJson(json['First'] as Map<String, dynamic>),
+      left: PaginatedResult<User>.fromJson(
+        json['Left'] as Map<String, dynamic>,
+        (value) => User.fromJson(value as Map<String, dynamic>),
+      ),
+      right: User.fromJson(json['Right'] as Map<String, dynamic>),
+    );
+
+Map<String, dynamic> _$ClashingArityFacetsToJson(
+  ClashingArityFacets instance,
+) => <String, dynamic>{
+  'First': instance.first,
+  'Left': instance.left.toJson((value) => value),
+  'Right': instance.right,
+};
+
+DifferentArityFacets _$DifferentArityFacetsFromJson(
+  Map<String, dynamic> json,
+) => DifferentArityFacets(
+  first: User.fromJson(json['First'] as Map<String, dynamic>),
+  left: User.fromJson(json['Left'] as Map<String, dynamic>),
+  right: PaginatedResult<User>.fromJson(
+    json['Right'] as Map<String, dynamic>,
+    (value) => User.fromJson(value as Map<String, dynamic>),
+  ),
+);
+
+Map<String, dynamic> _$DifferentArityFacetsToJson(
+  DifferentArityFacets instance,
+) => <String, dynamic>{
+  'First': instance.first,
+  'Left': instance.left,
+  'Right': instance.right.toJson((value) => value),
+};
+
+FacetQueryCombined _$FacetQueryCombinedFromJson(Map<String, dynamic> json) =>
+    FacetQueryCombined(
+      facet: User.fromJson(json['Facet'] as Map<String, dynamic>),
+      left: User.fromJson(json['Left'] as Map<String, dynamic>),
+      right: PaginatedResult<User>.fromJson(
+        json['Right'] as Map<String, dynamic>,
+        (value) => User.fromJson(value as Map<String, dynamic>),
+      ),
+    );
+
+Map<String, dynamic> _$FacetQueryCombinedToJson(FacetQueryCombined instance) =>
+    <String, dynamic>{
+      'Facet': instance.facet,
+      'Left': instance.left,
+      'Right': instance.right.toJson((value) => value),
+    };
+
+FacetQueryUser _$FacetQueryUserFromJson(Map<String, dynamic> json) =>
+    FacetQueryUser(facet: User.fromJson(json['Facet'] as Map<String, dynamic>));
+
+Map<String, dynamic> _$FacetQueryUserToJson(FacetQueryUser instance) =>
+    <String, dynamic>{'Facet': instance.facet};
+
+ForwardedAtSecondPosition<T> _$ForwardedAtSecondPositionFromJson<T>(
+  Map<String, dynamic> json,
+  T Function(Object? json) fromJsonT,
+) => ForwardedAtSecondPosition<T>(
+  first: fromJsonT(json['First']),
+  left: User.fromJson(json['Left'] as Map<String, dynamic>),
+  right: fromJsonT(json['Right']),
+);
+
+Map<String, dynamic> _$ForwardedAtSecondPositionToJson<T>(
+  ForwardedAtSecondPosition<T> instance,
+  Object? Function(T value) toJsonT,
+) => <String, dynamic>{
+  'First': toJsonT(instance.first),
+  'Left': instance.left,
+  'Right': toJsonT(instance.right),
+};
+
+ForwardedVarWithConcreteClash<T> _$ForwardedVarWithConcreteClashFromJson<T>(
+  Map<String, dynamic> json,
+  T Function(Object? json) fromJsonT,
+) => ForwardedVarWithConcreteClash<T>(
+  first: fromJsonT(json['First']),
+  second: User.fromJson(json['Second'] as Map<String, dynamic>),
+);
+
+Map<String, dynamic> _$ForwardedVarWithConcreteClashToJson<T>(
+  ForwardedVarWithConcreteClash<T> instance,
+  Object? Function(T value) toJsonT,
+) => <String, dynamic>{
+  'First': toJsonT(instance.first),
+  'Second': instance.second,
+};
+
+IFacetQuery<TFacet> _$IFacetQueryFromJson<TFacet>(
+  Map<String, dynamic> json,
+  TFacet Function(Object? json) fromJsonTFacet,
+) => IFacetQuery<TFacet>(facet: fromJsonTFacet(json['Facet']));
+
+Map<String, dynamic> _$IFacetQueryToJson<TFacet>(
+  IFacetQuery<TFacet> instance,
+  Object? Function(TFacet value) toJsonTFacet,
+) => <String, dynamic>{'Facet': toJsonTFacet(instance.facet)};
+
+IFirstFacet<TFirst> _$IFirstFacetFromJson<TFirst>(
+  Map<String, dynamic> json,
+  TFirst Function(Object? json) fromJsonTFirst,
+) => IFirstFacet<TFirst>(first: fromJsonTFirst(json['First']));
+
+Map<String, dynamic> _$IFirstFacetToJson<TFirst>(
+  IFirstFacet<TFirst> instance,
+  Object? Function(TFirst value) toJsonTFirst,
+) => <String, dynamic>{'First': toJsonTFirst(instance.first)};
+
+IPairFacet<TLeft, TRight> _$IPairFacetFromJson<TLeft, TRight>(
+  Map<String, dynamic> json,
+  TLeft Function(Object? json) fromJsonTLeft,
+  TRight Function(Object? json) fromJsonTRight,
+) => IPairFacet<TLeft, TRight>(
+  left: fromJsonTLeft(json['Left']),
+  right: fromJsonTRight(json['Right']),
+);
+
+Map<String, dynamic> _$IPairFacetToJson<TLeft, TRight>(
+  IPairFacet<TLeft, TRight> instance,
+  Object? Function(TLeft value) toJsonTLeft,
+  Object? Function(TRight value) toJsonTRight,
+) => <String, dynamic>{
+  'Left': toJsonTLeft(instance.left),
+  'Right': toJsonTRight(instance.right),
+};
+
+ISecondFacet<TSecond> _$ISecondFacetFromJson<TSecond>(
+  Map<String, dynamic> json,
+  TSecond Function(Object? json) fromJsonTSecond,
+) => ISecondFacet<TSecond>(second: fromJsonTSecond(json['Second']));
+
+Map<String, dynamic> _$ISecondFacetToJson<TSecond>(
+  ISecondFacet<TSecond> instance,
+  Object? Function(TSecond value) toJsonTSecond,
+) => <String, dynamic>{'Second': toJsonTSecond(instance.second)};
+
+MixedFacets _$MixedFacetsFromJson(Map<String, dynamic> json) => MixedFacets(
+  first: User.fromJson(json['First'] as Map<String, dynamic>),
+  second: PaginatedResult<User>.fromJson(
+    json['Second'] as Map<String, dynamic>,
+    (value) => User.fromJson(value as Map<String, dynamic>),
+  ),
+);
+
+Map<String, dynamic> _$MixedFacetsToJson(MixedFacets instance) =>
+    <String, dynamic>{
+      'First': instance.first,
+      'Second': instance.second.toJson((value) => value),
+    };
+
+SameFacets _$SameFacetsFromJson(Map<String, dynamic> json) => SameFacets(
+  first: User.fromJson(json['First'] as Map<String, dynamic>),
+  second: User.fromJson(json['Second'] as Map<String, dynamic>),
+);
+
+Map<String, dynamic> _$SameFacetsToJson(SameFacets instance) =>
+    <String, dynamic>{'First': instance.first, 'Second': instance.second};
+
 SearchResponse _$SearchResponseFromJson(Map<String, dynamic> json) =>
     SearchResponse(
       page: PaginatedResult<User>.fromJson(
@@ -89,12 +253,46 @@ Map<String, dynamic> _$SearchResponseToJson(SearchResponse instance) =>
       'Children': instance.children,
     };
 
+TwoForwardedVars<A, B> _$TwoForwardedVarsFromJson<A, B>(
+  Map<String, dynamic> json,
+  A Function(Object? json) fromJsonA,
+  B Function(Object? json) fromJsonB,
+) => TwoForwardedVars<A, B>(
+  first: fromJsonA(json['First']),
+  second: fromJsonB(json['Second']),
+);
+
+Map<String, dynamic> _$TwoForwardedVarsToJson<A, B>(
+  TwoForwardedVars<A, B> instance,
+  Object? Function(A value) toJsonA,
+  Object? Function(B value) toJsonB,
+) => <String, dynamic>{
+  'First': toJsonA(instance.first),
+  'Second': toJsonB(instance.second),
+};
+
 User _$UserFromJson(Map<String, dynamic> json) =>
     User(id: json['Id'] as String, name: json['Name'] as String);
 
 Map<String, dynamic> _$UserToJson(User instance) => <String, dynamic>{
   'Id': instance.id,
   'Name': instance.name,
+};
+
+VarBoundTwice<T> _$VarBoundTwiceFromJson<T>(
+  Map<String, dynamic> json,
+  T Function(Object? json) fromJsonT,
+) => VarBoundTwice<T>(
+  left: fromJsonT(json['Left']),
+  right: fromJsonT(json['Right']),
+);
+
+Map<String, dynamic> _$VarBoundTwiceToJson<T>(
+  VarBoundTwice<T> instance,
+  Object? Function(T value) toJsonT,
+) => <String, dynamic>{
+  'Left': toJsonT(instance.left),
+  'Right': toJsonT(instance.right),
 };
 
 ISomethingRelated _$ISomethingRelatedFromJson(Map<String, dynamic> json) =>

--- a/packages/leancode_contracts_generator/lib/src/statements/dto_handler.dart
+++ b/packages/leancode_contracts_generator/lib/src/statements/dto_handler.dart
@@ -1,7 +1,5 @@
 import 'package:code_builder/code_builder.dart';
-import 'package:collection/collection.dart';
 
-import '../utils/rename_type.dart';
 import 'statement_handler.dart';
 
 class DtoHandler extends StatementHandler {
@@ -25,111 +23,8 @@ class DtoHandler extends StatementHandler {
           ..annotations.clear()
           ..methods.clear()
           ..constructors.removeWhere((e) => e.name == 'fromJson');
-        return;
-      }
-
-      // a subclass of a generic DTO needs a toJson that overrides the base's
-      if (_inheritedToJson(statement) case final toJson?) {
-        b.methods
-          ..removeWhere((m) => m.name == 'toJson')
-          ..add(toJson);
       }
     });
-  }
-
-  /// A `toJson` override for a DTO extending a generic DTO, or `null` otherwise.
-  ///
-  /// A generic DTO's generated `toJson` takes one `Object? Function(T)` factory
-  /// per type parameter; extending it forces an override-compatible `toJson`, so
-  /// the factories can't be dropped. Here they're all *optional* (a concrete
-  /// subclass stays callable as `toJson()`), ordered by the base's type
-  /// arguments for override compatibility ([_toJsonFactoryParameters]) but
-  /// forwarded to `_$ChildToJson` in the child's order ([_toJsonForwardedArguments]).
-  ///
-  /// e.g. `ChildResult<T> extends PaginatedResult<T>` gets
-  /// `toJson([Object? Function(T)? toJsonT]) =>`
-  /// `    _$ChildResultToJson(this, toJsonT ?? ((v) => v))`.
-  Method? _inheritedToJson(Statement statement) {
-    if (_extendedGenericBase(statement) case final base?) {
-      final name = renameType(db.resolveName(statement.name));
-      final childParams = statement.dto.typeDescriptor.genericParameters
-          .map((g) => g.name)
-          .toList();
-
-      return Method(
-        (m) => m
-          ..name = 'toJson'
-          ..lambda = true
-          ..returns = refer('Map<String, dynamic>')
-          ..optionalParameters.addAll(
-            _toJsonFactoryParameters(base, childParams),
-          )
-          ..body = Code(
-            '_\$${name}ToJson(${_toJsonForwardedArguments(childParams).join(', ')})',
-          ),
-      );
-    }
-
-    return null;
-  }
-
-  /// The generic DTO this one extends (at most one — a C# base class), whose
-  /// `toJson` the override has to stay compatible with, or `null` if there's none.
-  TypeRef? _extendedGenericBase(Statement statement) {
-    return statement.dto.typeDescriptor.extends_1.firstWhereOrNull((e) {
-      // Only a type we generate can be the base whose `toJson` we override, and
-      // dropping the ones config excludes keeps us in sync with `createBase`,
-      // which extends only included bases. The guard also makes reading
-      // `e.internal.name` below safe (a non-internal ref has no name).
-      if (!e.hasInternal() || !db.shouldInclude(e.internal.name)) {
-        return false;
-      }
-      final resolved = db.find(e.internal.name);
-      return resolved != null &&
-          resolved.hasDto() &&
-          resolved.dto.typeDescriptor.genericParameters.isNotEmpty;
-    });
-  }
-
-  /// Optional `Object? Function(T)?` factory parameters, in the base's
-  /// type-argument order then one per child param the base doesn't cover.
-  /// A factory bound to a child type variable is named `toJson<var>` so
-  /// [_toJsonForwardedArguments] can forward it; one for a *concrete* base
-  /// argument is unused, so it's named `_` (a wildcard) to make that explicit.
-  List<Parameter> _toJsonFactoryParameters(
-    TypeRef base,
-    List<String> childParams,
-  ) {
-    final baseVars = {
-      for (final arg in base.internal.arguments)
-        if (arg.hasGeneric()) arg.generic.name,
-    };
-
-    Parameter optionalFactory(String on, String named) => Parameter(
-      (p) => p
-        ..name = named
-        ..type = refer('Object? Function($on)?'),
-    );
-
-    return [
-      for (final arg in base.internal.arguments)
-        optionalFactory(
-          typeCreator.create(arg).symbol!,
-          arg.hasGeneric() ? 'toJson${arg.generic.name}' : '_',
-        ),
-      for (final param in childParams.where((p) => !baseVars.contains(p)))
-        optionalFactory(param, 'toJson$param'),
-    ];
-  }
-
-  /// Arguments forwarded to the generated `_$ChildToJson`, in the child's
-  /// type-parameter declaration order (what json_serializable expects). An
-  /// omitted optional factory falls back to the identity function.
-  List<String> _toJsonForwardedArguments(List<String> childParams) {
-    return [
-      'this',
-      for (final param in childParams) 'toJson$param ?? ((v) => v)',
-    ];
   }
 
   @override

--- a/packages/leancode_contracts_generator/lib/src/statements/statement_handler.dart
+++ b/packages/leancode_contracts_generator/lib/src/statements/statement_handler.dart
@@ -55,7 +55,7 @@ abstract class StatementHandler {
 
     db.markAsUsingJsonSerialization();
 
-    return Class((b) {
+    final base = Class((b) {
       b
         ..name = name
         ..fields.addAll([
@@ -161,6 +161,130 @@ abstract class StatementHandler {
         )
         ..mixins.add(refer('Equatable'));
     });
+
+    // A type extending/implementing a generic base must override its `toJson`.
+    if (_inheritedToJson(statement) case final toJson?) {
+      return base.rebuild(
+        (b) => b.methods
+          ..removeWhere((m) => m.name == 'toJson')
+          ..add(toJson),
+      );
+    }
+
+    return base;
+  }
+
+  /// A `toJson` override for a type extending/implementing a generic base, or
+  /// `null` otherwise.
+  ///
+  /// A generic base's generated `toJson` takes one `Object? Function(T)` factory
+  /// per type parameter, so extending it forces an override-compatible `toJson`.
+  /// Here the factories are all *optional* (a concrete subtype stays callable as
+  /// `toJson()`), ordered for override compatibility ([_toJsonFactoryParameters])
+  /// but forwarded to `_$ChildToJson` in the child's order
+  /// ([_toJsonForwardedArguments]).
+  ///
+  /// e.g. `ChildResult<T> extends PaginatedResult<T>` gets
+  /// `toJson([Object? Function(T)? toJsonT]) =>`
+  /// `    _$ChildResultToJson(this, toJsonT ?? ((v) => v))`.
+  Method? _inheritedToJson(Statement statement) {
+    final bases = _extendedGenericBases(statement);
+    if (bases.isEmpty) {
+      return null;
+    }
+
+    final name = renameType(db.resolveName(statement.name));
+    final childParams = typeDescriptorOf(
+      statement,
+    )!.genericParameters.map((g) => g.name).toList();
+
+    return Method(
+      (m) => m
+        ..name = 'toJson'
+        ..lambda = true
+        ..returns = refer('Map<String, dynamic>')
+        ..optionalParameters.addAll(
+          _toJsonFactoryParameters(bases, childParams),
+        )
+        ..body = Code(
+          '_\$${name}ToJson(${_toJsonForwardedArguments(childParams).join(', ')})',
+        ),
+    );
+  }
+
+  /// The generic bases this statement extends/implements — a C# base class
+  /// and/or one or more generic interfaces — whose `toJson` the override has to
+  /// stay compatible with. Empty if there are none.
+  List<TypeRef> _extendedGenericBases(Statement statement) {
+    // Non-null: createBase already rejects typeless statements.
+    return typeDescriptorOf(statement)!.extends_1.where((e) {
+      // Only a type we generate can be a base whose `toJson` we override, and
+      // dropping the ones config excludes keeps us in sync with `createBase`,
+      // which extends only included bases. The guard also makes reading
+      // `e.internal.name` below safe (a non-internal ref has no name).
+      if (!e.hasInternal() || !db.shouldInclude(e.internal.name)) {
+        return false;
+      }
+      final resolved = db.find(e.internal.name);
+      return resolved != null &&
+          resolved.hasDto() &&
+          resolved.dto.typeDescriptor.genericParameters.isNotEmpty;
+    }).toList();
+  }
+
+  /// Optional factory parameters for the override: one per position of the
+  /// widest base, plus one per child type variable no position forwards.
+  ///
+  /// A position all bases bind to the same type variable forwards it as
+  /// `Object? Function(<var>)?` named `toJson<var>`, but only from its first
+  /// such position. Any other position — a disagreement, a concrete type, or a
+  /// variable forwarded earlier (as in `IPairFacet<T, T>`) — is unused:
+  /// `Object? Function(Never)?` named `_` (`Never` validly overrides any type).
+  List<Parameter> _toJsonFactoryParameters(
+    List<TypeRef> bases,
+    List<String> childParams,
+  ) {
+    Parameter optionalFactory(String? childVar) => Parameter(
+      (p) => p
+        ..name = childVar != null ? 'toJson$childVar' : '_'
+        ..type = refer('Object? Function(${childVar ?? 'Never'})?'),
+    );
+
+    final arity = bases.map((b) => b.internal.arguments.length).max;
+
+    // The variable each position agrees on, or null if the bases disagree or
+    // bind a concrete type there.
+    final agreed = [
+      for (var i = 0; i < arity; i++)
+        bases
+            .map((b) => b.internal.arguments)
+            .where((args) => i < args.length)
+            .map((args) => args[i].hasGeneric() ? args[i].generic.name : null)
+            .toSet()
+            .singleOrNull,
+    ];
+
+    // Forward each variable only from its first position, so one bound at
+    // several positions doesn't emit duplicate parameter names.
+    final forwarded = <String>{};
+    return [
+      for (final childVar in agreed)
+        optionalFactory(
+          childVar != null && forwarded.add(childVar) ? childVar : null,
+        ),
+      for (final param in childParams.whereNot(forwarded.contains))
+        optionalFactory(param),
+    ];
+  }
+
+  /// Arguments forwarded to the generated `_$ChildToJson`, in the child's
+  /// type-parameter declaration order (what json_serializable expects). An
+  /// omitted optional factory falls back to the identity function.
+  List<String> _toJsonForwardedArguments(List<String> childParams) {
+    return [
+      'this',
+      for (final param in childParams) 'toJson$param ?? ((v) => v)',
+    ];
   }
 
   Parameter _createParameter(PropertyRef prop, {required bool required}) {

--- a/packages/leancode_contracts_generator/test/integration_test.dart
+++ b/packages/leancode_contracts_generator/test/integration_test.dart
@@ -122,8 +122,8 @@ void main() {
     }
   });
 
-  // generic DTOs and their subclasses must not just compile — the whole graph
-  // has to survive jsonEncode and round-trip back to an equal value.
+  // Types extending/implementing a generic base must not just compile — the
+  // whole graph has to survive jsonEncode and round-trip back to an equal value.
   test('generic DTOs round-trip via jsonEncode', () async {
     await ContractsGenerator(
       ContractsGeneratorConfig(
@@ -153,30 +153,82 @@ extension on Directory {
   Iterable<File> listFiles() => listSync().whereType<File>();
 }
 
-// Builds the fixtures — a generic DTO as a concrete field, a concrete
-// subclass and a generic subclass — encodes and decodes them, and throws
-// (→ failing test) if the value doesn't survive the trip.
-const _roundTripMain = '''
+// Builds a fixture for each shape that gets a `toJson` override — generic DTO
+// inheritance, concrete DTOs implementing several generic interfaces, a query
+// implementing one, and generic implementers that forward their type variable —
+// encodes and decodes each, and throws (→ failing test) on any that doesn't
+// survive the trip.
+const _roundTripMain = r'''
 import 'dart:convert';
 
 import 'package:integration_test_project/contracts.dart';
 
+Map<String, dynamic> _enc(Object value) =>
+    jsonDecode(jsonEncode(value)) as Map<String, dynamic>;
+
+User _user(Object? json) => User.fromJson(json as Map<String, dynamic>);
+
+void _expect(Object value, Object decoded) {
+  if (decoded != value) {
+    throw StateError('round-trip changed the value: $value != $decoded');
+  }
+}
+
 void main() {
+  final a = User(id: '1', name: 'a');
+  final b = User(id: '2', name: 'b');
+  final c = User(id: '3', name: 'c');
+  final page = PaginatedResult<User>(items: [a], totalCount: 1);
+
+  // generic DTO used as a field, a concrete subclass and a generic subclass
   final response = SearchResponse(
-    page: PaginatedResult<User>(items: [User(id: '1', name: 'a')], totalCount: 1),
-    allUsers: AllUsersResult(items: [User(id: '2', name: 'b')], totalCount: 1),
-    children: ChildResult<User>(
-      items: [User(id: '3', name: 'c')],
-      totalCount: 1,
-      extras: [User(id: '4', name: 'd')],
-    ),
+    page: page,
+    allUsers: AllUsersResult(items: [b], totalCount: 1),
+    children: ChildResult<User>(items: [c], totalCount: 1, extras: [a]),
+  );
+  _expect(response, SearchResponse.fromJson(_enc(response)));
+
+  // concrete DTOs implementing several generic interfaces (unused `Never` slots)
+  final same = SameFacets(first: a, second: b);
+  _expect(same, SameFacets.fromJson(_enc(same)));
+
+  final mixed = MixedFacets(first: a, second: page);
+  _expect(mixed, MixedFacets.fromJson(_enc(mixed)));
+
+  final differentArity = DifferentArityFacets(first: a, left: b, right: page);
+  _expect(differentArity, DifferentArityFacets.fromJson(_enc(differentArity)));
+
+  final clashingArity = ClashingArityFacets(first: a, left: page, right: b);
+  _expect(clashingArity, ClashingArityFacets.fromJson(_enc(clashingArity)));
+
+  // a query implementing a generic interface, and one combined with a 2-arity one
+  final query = FacetQueryUser(facet: a);
+  _expect(query, FacetQueryUser.fromJson(_enc(query)));
+
+  final combined = FacetQueryCombined(facet: a, left: b, right: page);
+  _expect(combined, FacetQueryCombined.fromJson(_enc(combined)));
+
+  // generic implementers forwarding their own type variable
+  final forwarded = ForwardedAtSecondPosition<User>(first: a, left: b, right: c);
+  _expect(
+    forwarded,
+    ForwardedAtSecondPosition<User>.fromJson(_enc(forwarded), _user),
   );
 
-  final decoded = SearchResponse.fromJson(
-    jsonDecode(jsonEncode(response)) as Map<String, dynamic>,
+  final concreteClash = ForwardedVarWithConcreteClash<User>(first: a, second: b);
+  _expect(
+    concreteClash,
+    ForwardedVarWithConcreteClash<User>.fromJson(_enc(concreteClash), _user),
   );
-  if (decoded != response) {
-    throw StateError('round-trip changed the value');
-  }
+
+  final twoVars = TwoForwardedVars<User, User>(first: a, second: b);
+  _expect(
+    twoVars,
+    TwoForwardedVars<User, User>.fromJson(_enc(twoVars), _user, _user),
+  );
+
+  // one variable bound at both positions of a base (forwarded once, then unused)
+  final boundTwice = VarBoundTwice<User>(left: a, right: b);
+  _expect(boundTwice, VarBoundTwice<User>.fromJson(_enc(boundTwice), _user));
 }
 ''';


### PR DESCRIPTION
The previous generics fix handled serialization of generic DTOs used as concrete fields by emitting a signature-compatible toJson override on types extending a generic DTO. That logic lived in DtoHandler and assumed a single base, which left two gaps:

1. Non-DTO statements (queries, commands, operations, topics) implementing a generic interface never got the override, so build_runner failed with "Could not generate toJson code".
2. A class can implement several generic interfaces at once - the old logic only accounted for one base, so the override wasn't compatible with all generated toJsons.

Changes vs #111 

- Moved `_inheritedToJson` from `dto_handler.dart` into the shared `StatementHandler.createBase`, so every generated type gets the override, not just DTOs.
- Generalized from a single base to multiple generic bases: the override widens to the largest arity, forwards each type variable only from the first position all bases agree on, and marks unused positions (concrete-type clashes, duplicates) as `Object? Function(Never)?`.

Tests

Added C# fixtures (`MultiGenericInterface`, `ForwardedGenericImplementers`, `SharedInterfaceQueries`) covering multiple interfaces, differing arities, concrete-type clashes, a variable bound at several positions, and a non-DTO implementing a generic interface - exercised by the end-to-end integration + `toJson` roundtrip test.