### PR TITLE
Bump leancode_contracts_generator to v0.19.0

### DIFF
--- a/.github/workflows/leancode_contracts_generator-publish.yml
+++ b/.github/workflows/leancode_contracts_generator-publish.yml
@@ -23,7 +23,7 @@ jobs:
 
       - uses: dart-lang/setup-dart@v1
         with:
-          sdk: 3.8
+          sdk: 3.9
 
       - name: Publish to pub.dev
         run: |

--- a/packages/leancode_contracts_generator/CHANGELOG.md
+++ b/packages/leancode_contracts_generator/CHANGELOG.md
@@ -1,3 +1,9 @@
+# 0.19.0
+
+- **BREAKING**: Bump Dart SDK to 3.9.0
+- **BREAKING**: Generate serialization with an own builder instead of relying on `json_serializable` to pick up `@ContractsSerializable`. Requires `package:leancode_contracts` v0.10.0
+- Serialize generic DTOs used as concrete fields in the builder (#95), replacing the 0.18.1 fix, which silently broke generics with enums and types implementing multiple generic interfaces
+
 # 0.18.1
 
 - Fix serialization of generic DTOs used as concrete fields (#95)

--- a/packages/leancode_contracts_generator/pubspec.yaml
+++ b/packages/leancode_contracts_generator/pubspec.yaml
@@ -1,7 +1,7 @@
 name: leancode_contracts_generator
 repository: https://github.com/leancodepl/contractsgenerator-dart
 description: Dart contracts client generator for a CQRS API.
-version: 0.18.1
+version: 0.19.0
 
 environment:
   sdk: ">=3.9.0 <4.0.0"
@@ -15,7 +15,7 @@ dependencies:
   dart_style: ^3.1.1
   fixnum: ^1.1.1
   json_serializable: ^6.11.0
-  leancode_contracts: ^0.9.0
+  leancode_contracts: ^0.10.0
   meta: ^1.16.0
   path: ^1.9.1
   protobuf: ^4.2.0
@@ -28,10 +28,6 @@ dev_dependencies:
   leancode_lint: ^19.0.0
   leancode_pipe: ^2.0.0
   test: ^1.26.3
-
-dependency_overrides:
-  leancode_contracts:
-    path: ../leancode_contracts
 
 executables:
   leancode_contracts_generator: leancode_contracts_generator


### PR DESCRIPTION
Bump leancode_contracts_generator version to 0.19.0

Serialization of generic DTOs used as concrete fields can't be fixed from the outside - the 0.18.1 attempt patched it with a generated `toJson` override and silently broke generics with enums and types implementing multiple generic interfaces. Fixing it properly needs control over how fields are serialized, hence an own `contracts_serializable` builder instead of relying on `json_serializable` to pick up `@ContractsSerializable`.