### PR TITLE
Generate const constructors for contracts

### DIFF
--- a/packages/leancode_contracts_generator/CHANGELOG.md
+++ b/packages/leancode_contracts_generator/CHANGELOG.md
@@ -1,3 +1,7 @@
+# 0.19.1
+
+- Generate `const` constructors for DTOs, queries, commands, operations and topics (#110)
+
 # 0.19.0
 
 - **BREAKING**: Bump Dart SDK to 3.9.0

--- a/packages/leancode_contracts_generator/example/lib/cool_name.dart
+++ b/packages/leancode_contracts_generator/example/lib/cool_name.dart
@@ -8,7 +8,7 @@ part 'cool_name.g.dart';
 
 @ContractsSerializable()
 class Auth with Equatable {
-  Auth();
+  const Auth();
 
   factory Auth.fromJson(Map<String, dynamic> json) => _$AuthFromJson(json);
 
@@ -22,7 +22,7 @@ class Auth with Equatable {
 
 @ContractsSerializable()
 class KnownClaims with Equatable {
-  KnownClaims();
+  const KnownClaims();
 
   factory KnownClaims.fromJson(Map<String, dynamic> json) =>
       _$KnownClaimsFromJson(json);
@@ -41,7 +41,7 @@ class KnownClaims with Equatable {
 
 @ContractsSerializable()
 class Roles with Equatable {
-  Roles();
+  const Roles();
 
   factory Roles.fromJson(Map<String, dynamic> json) => _$RolesFromJson(json);
 
@@ -63,7 +63,7 @@ class Roles with Equatable {
 abstract class PaginatedQuery<TResult>
     with Equatable
     implements Query<PaginatedResult<TResult>> {
-  PaginatedQuery({required this.pageNumber, required this.pageSize});
+  const PaginatedQuery({required this.pageNumber, required this.pageSize});
 
   final int pageNumber;
 
@@ -76,7 +76,7 @@ abstract class PaginatedQuery<TResult>
 /// This one is in XML.
 @ContractsSerializable(genericArgumentFactories: true)
 class PaginatedResult<TResult> with Equatable {
-  PaginatedResult({required this.items, required this.totalCount});
+  const PaginatedResult({required this.items, required this.totalCount});
 
   factory PaginatedResult.fromJson(
     Map<String, dynamic> json,
@@ -96,7 +96,7 @@ class PaginatedResult<TResult> with Equatable {
 
 @ContractsSerializable()
 class ISomethingRelated with Equatable {
-  ISomethingRelated({required this.somethingId});
+  const ISomethingRelated({required this.somethingId});
 
   factory ISomethingRelated.fromJson(Map<String, dynamic> json) =>
       _$ISomethingRelatedFromJson(json);
@@ -115,7 +115,7 @@ class ISomethingRelated with Equatable {
 /// System.Diagnostics.CodeAnalysis.SuppressMessageAttribute('?', 'IDE1006', Justification: 'Convention for authorizers.')
 @ContractsSerializable()
 class WhenHasSomethingAccess with Equatable {
-  WhenHasSomethingAccess();
+  const WhenHasSomethingAccess();
 
   factory WhenHasSomethingAccess.fromJson(Map<String, dynamic> json) =>
       _$WhenHasSomethingAccessFromJson(json);
@@ -131,7 +131,7 @@ class WhenHasSomethingAccess with Equatable {
 /// LeanCode.Contracts.Security.AuthorizeWhenHasAnyOfAttribute('admin')
 @ContractsSerializable()
 class AllUsers with Equatable implements PaginatedQuery<UserInfoDTO> {
-  AllUsers({required this.pageNumber, required this.pageSize});
+  const AllUsers({required this.pageNumber, required this.pageSize});
 
   factory AllUsers.fromJson(Map<String, dynamic> json) =>
       _$AllUsersFromJson(json);
@@ -160,7 +160,7 @@ class AllUsers with Equatable implements PaginatedQuery<UserInfoDTO> {
 /// LeanCode.ContractsGeneratorV2.ExampleContracts.Security.AuthorizeWhenHasSomethingAccessAttribute()
 @ContractsSerializable()
 class EditUser with Equatable implements Command, ISomethingRelated {
-  EditUser({
+  const EditUser({
     required this.somethingId,
     required this.userId,
     required this.list,
@@ -228,7 +228,7 @@ class EditUserErrorCodes {
 /// LeanCode.Contracts.Security.AuthorizeWhenHasAnyOfAttribute('admin')
 @ContractsSerializable()
 class UserById with Equatable implements Query<UserInfoDTO?> {
-  UserById();
+  const UserById();
 
   factory UserById.fromJson(Map<String, dynamic> json) =>
       _$UserByIdFromJson(json);
@@ -250,7 +250,7 @@ class UserById with Equatable implements Query<UserInfoDTO?> {
 @Deprecated('Use something else instead')
 @ContractsSerializable()
 class UserInfoDTO with Equatable {
-  UserInfoDTO({
+  const UserInfoDTO({
     required this.firstname,
     required this.surname,
     required this.username,
@@ -280,7 +280,7 @@ class UserInfoDTO with Equatable {
 /// LeanCode.Contracts.Security.AuthorizeWhenHasAnyOfAttribute('admin')
 @ContractsSerializable()
 class UserSomething with Equatable implements Query<int?> {
-  UserSomething();
+  const UserSomething();
 
   factory UserSomething.fromJson(Map<String, dynamic> json) =>
       _$UserSomethingFromJson(json);

--- a/packages/leancode_contracts_generator/example/lib/data/contracts.dart
+++ b/packages/leancode_contracts_generator/example/lib/data/contracts.dart
@@ -7,7 +7,7 @@ part 'contracts.g.dart';
 /// LeanCode.Contracts.Security.AllowUnauthorizedAttribute()
 @ContractsSerializable()
 class Command_ with Equatable implements Command {
-  Command_();
+  const Command_();
 
   factory Command_.fromJson(Map<String, dynamic> json) =>
       _$Command_FromJson(json);
@@ -26,7 +26,7 @@ class CommandErrorCodes {}
 /// LeanCode.Contracts.Security.AllowUnauthorizedAttribute()
 @ContractsSerializable()
 class Query_ with Equatable implements Query<int> {
-  Query_();
+  const Query_();
 
   factory Query_.fromJson(Map<String, dynamic> json) => _$Query_FromJson(json);
 
@@ -43,7 +43,7 @@ class Query_ with Equatable implements Query<int> {
 
 @ContractsSerializable()
 class Notification with Equatable implements TopicNotification {
-  Notification();
+  const Notification();
 
   factory Notification.fromJson(Map<String, dynamic> json) =>
       _$NotificationFromJson(json);
@@ -57,7 +57,7 @@ class Notification with Equatable implements TopicNotification {
 
 @ContractsSerializable()
 class Topic_ with Equatable implements Topic<TopicNotification> {
-  Topic_();
+  const Topic_();
 
   factory Topic_.fromJson(Map<String, dynamic> json) => _$Topic_FromJson(json);
 

--- a/packages/leancode_contracts_generator/lib/src/statements/statement_handler.dart
+++ b/packages/leancode_contracts_generator/lib/src/statements/statement_handler.dart
@@ -69,7 +69,11 @@ abstract class StatementHandler {
           ),
         ])
         ..constructors.addAll([
-          Constructor((b) => b..optionalParameters.addAll(parameters)),
+          Constructor(
+            (b) => b
+              ..constant = true
+              ..optionalParameters.addAll(parameters),
+          ),
           Constructor(
             (b) => b
               ..factory = true

--- a/packages/leancode_contracts_generator/pubspec.yaml
+++ b/packages/leancode_contracts_generator/pubspec.yaml
@@ -1,7 +1,7 @@
 name: leancode_contracts_generator
 repository: https://github.com/leancodepl/contractsgenerator-dart
 description: Dart contracts client generator for a CQRS API.
-version: 0.19.0+1
+version: 0.19.1
 
 environment:
   sdk: ">=3.9.0 <4.0.0"

--- a/packages/leancode_contracts_generator/test/statement_handler_test.dart
+++ b/packages/leancode_contracts_generator/test/statement_handler_test.dart
@@ -1,0 +1,222 @@
+import 'package:code_builder/code_builder.dart';
+import 'package:dart_style/dart_style.dart';
+import 'package:leancode_contracts_generator/leancode_contracts_generator.dart';
+import 'package:leancode_contracts_generator/src/attributes/attribute_creator.dart';
+import 'package:leancode_contracts_generator/src/errors/error_creator.dart';
+import 'package:leancode_contracts_generator/src/generator_database.dart';
+import 'package:leancode_contracts_generator/src/json_converters/json_converters.dart';
+import 'package:leancode_contracts_generator/src/proto/contracts.pb.dart';
+import 'package:leancode_contracts_generator/src/statements/command_handler.dart';
+import 'package:leancode_contracts_generator/src/statements/dto_handler.dart';
+import 'package:leancode_contracts_generator/src/statements/operation_handler.dart';
+import 'package:leancode_contracts_generator/src/statements/query_handler.dart';
+import 'package:leancode_contracts_generator/src/statements/topic_handler.dart';
+import 'package:leancode_contracts_generator/src/types/generic_type_handler.dart';
+import 'package:leancode_contracts_generator/src/types/internal_type_handler.dart';
+import 'package:leancode_contracts_generator/src/types/known_type_handler.dart';
+import 'package:leancode_contracts_generator/src/types/type_creator.dart';
+import 'package:leancode_contracts_generator/src/values/value_creator.dart';
+import 'package:test/test.dart';
+
+final _emitter = DartEmitter();
+
+TypeRef _known(KnownType type) => TypeRef(known: TypeRef_Known(type: type));
+
+TypeDescriptor _descriptor({
+  Iterable<TypeRef> extends_ = const [],
+  Iterable<GenericParameter> genericParameters = const [],
+}) => TypeDescriptor(
+  extends_1: extends_,
+  genericParameters: genericParameters,
+  properties: [
+    PropertyRef(name: 'Id', type: _known(KnownType.String)),
+    PropertyRef(name: 'Count', type: _known(KnownType.Int32)),
+  ],
+);
+
+String _build(Statement statement, {Iterable<Statement> others = const []}) {
+  final db = GeneratorDatabase(
+    ContractsGeneratorConfig(input: GeneratorScript.project([])),
+    Export(statements: [statement, ...others]),
+  );
+
+  final typeCreator = TypeCreator([
+    const KnownTypeHandler(),
+    const GenericTypeHandler(),
+    InternalTypeHandler(db),
+  ]);
+  const valueCreator = ValueCreator();
+  const attributeCreator = AttributeCreator(valueCreator);
+  final jsonConverters = JsonConverters();
+
+  final handlers = [
+    DtoHandler(typeCreator, valueCreator, attributeCreator, db),
+    QueryHandler(
+      typeCreator,
+      valueCreator,
+      attributeCreator,
+      jsonConverters,
+      db,
+    ),
+    CommandHandler(
+      typeCreator,
+      valueCreator,
+      attributeCreator,
+      db,
+      const ErrorCreator(),
+    ),
+    OperationHandler(
+      typeCreator,
+      valueCreator,
+      attributeCreator,
+      jsonConverters,
+      db,
+    ),
+    TopicHandler(
+      typeCreator,
+      valueCreator,
+      attributeCreator,
+      jsonConverters,
+      db,
+    ),
+  ];
+
+  final handler = handlers.firstWhere((h) => h.canHandle(statement));
+
+  return DartFormatter(
+    languageVersion: DartFormatter.latestLanguageVersion,
+  ).format(handler.build(statement).accept(_emitter).toString());
+}
+
+void main() {
+  group('createBase', () {
+    test('generates a const constructor for DTOs', () {
+      final code = _build(
+        Statement(
+          name: 'A.Dto',
+          dto: Statement_DTO(typeDescriptor: _descriptor()),
+        ),
+      );
+
+      expect(
+        code,
+        contains('const Dto({required this.id, required this.count})'),
+      );
+    });
+
+    test('generates a const constructor for queries', () {
+      final code = _build(
+        Statement(
+          name: 'A.SomeQuery',
+          query: Statement_Query(
+            typeDescriptor: _descriptor(),
+            returnType: _known(KnownType.Int32),
+          ),
+        ),
+      );
+
+      expect(
+        code,
+        contains('const SomeQuery({required this.id, required this.count})'),
+      );
+    });
+
+    test('generates a const constructor for commands', () {
+      final code = _build(
+        Statement(
+          name: 'A.SomeCommand',
+          command: Statement_Command(typeDescriptor: _descriptor()),
+        ),
+      );
+
+      expect(
+        code,
+        contains('const SomeCommand({required this.id, required this.count})'),
+      );
+    });
+
+    test('generates a const constructor for operations', () {
+      final code = _build(
+        Statement(
+          name: 'A.SomeOperation',
+          operation: Statement_Operation(
+            typeDescriptor: _descriptor(),
+            returnType: _known(KnownType.Int32),
+          ),
+        ),
+      );
+
+      expect(
+        code,
+        contains(
+          'const SomeOperation({required this.id, required this.count})',
+        ),
+      );
+    });
+
+    test('generates a const constructor for topics', () {
+      final code = _build(
+        Statement(
+          name: 'A.SomeTopic',
+          topic: Statement_Topic(
+            typeDescriptor: _descriptor(),
+            notifications: [
+              NotificationTypeRef(
+                tag: 'A.Notification',
+                type: TypeRef(
+                  internal: TypeRef_Internal(name: 'A.Notification'),
+                ),
+              ),
+            ],
+          ),
+        ),
+        others: [
+          Statement(
+            name: 'A.Notification',
+            dto: Statement_DTO(typeDescriptor: TypeDescriptor()),
+          ),
+        ],
+      );
+
+      expect(
+        code,
+        contains('const SomeTopic({required this.id, required this.count})'),
+      );
+    });
+
+    test('generates a const constructor for generic DTOs', () {
+      final code = _build(
+        Statement(
+          name: 'A.Box',
+          dto: Statement_DTO(
+            typeDescriptor: _descriptor(
+              genericParameters: [GenericParameter(name: 'T')],
+            ),
+          ),
+        ),
+      );
+
+      expect(
+        code,
+        contains('const Box({required this.id, required this.count})'),
+      );
+    });
+
+    test('generates a const constructor for abstract protocol DTOs', () {
+      final code = _build(
+        Statement(
+          name: 'A.Base',
+          dto: Statement_DTO(
+            typeDescriptor: _descriptor(extends_: [_known(KnownType.Command)]),
+          ),
+        ),
+      );
+
+      expect(code, contains('abstract class Base'));
+      expect(
+        code,
+        contains('const Base({required this.id, required this.count})'),
+      );
+    });
+  });
+}


### PR DESCRIPTION
Closes #110.

## Change

`createBase` in `lib/src/statements/statement_handler.dart` now emits the unnamed constructor as `const`. That's the single shared code path, so it covers DTOs, queries, commands, operations, topics, generic DTOs, and the abstract protocol base classes in one place.

Generated contracts are eligible for this: every field is `final`, and the only supertype in the mixin/superclass chain is `Equatable`, which is `abstract mixin class Equatable` with a `const Equatable()` and no instance fields.

## This does not need a cqrs change

leancodepl/flutter_corelibrary#551 assumed the CQRS base classes were the blocker. They aren't. `Query`, `Command` and `Operation` are `abstract interface class` in `packages/cqrs/lib/src/transport_types.dart`, and `Topic` in `leancode_pipe` is too — so generated contracts *implement* them and never extend them (`interface class` forbids extending outside the declaring library anyway). An `implements` clause places no constraint on whether a constructor can be `const`. For completeness, the cqrs result types (`QueryResult`, `CommandResult`, `ValidationError`, …) already declare const constructors.

So #551 can be closed as not needed.

## Verification

- New `test/statement_handler_test.dart` covers each statement kind, generics, and abstract protocol DTOs. The cases fail when the `constant = true` line is reverted.
- The checked-in example outputs (`example/lib/cool_name.dart`, `example/lib/data/contracts.dart`) are updated. Re-running `build_runner` in the example package produced byte-identical `.g.dart` files, and `dart analyze` reports only the two deprecation infos that were already there.
- Compiled and ran the example's generated contracts against the real dependency graph: `const AllUsers(pageNumber: 1, pageSize: 10)` works, canonicalizes (`identical` is `true`), and `toJson()` is unaffected.
- `dart analyze lib test`, `dart format` and the unit test suite are clean.

**Not run:** `test/integration_test.dart`, which needs `dotnet` and the `contractsgenerator` submodule — neither was available in my environment. That's the test that compiles output across the full C# example corpus, so CI should be the gate on the long tail of contract shapes.

## Release

Version bumped `0.19.0+1` → `0.19.1` with a CHANGELOG entry. The change is additive and source-compatible for consumers, matching how 0.17.1 was handled.


---
_Generated by [Claude Code](https://claude.ai/code/session_017gTtF68U3wupiodg2JeaGp)_